### PR TITLE
allow select modal to search special charachers

### DIFF
--- a/components/select-modal.tsx
+++ b/components/select-modal.tsx
@@ -127,12 +127,19 @@ function Modal({
                 const v2 = b.isSelected ? 1 : 0;
                 return v2 - v1;
             })
-            .filter(o => JSON.stringify([
-                o.value || '', 
-                o.label || '', 
-                // o.caption || '', 
-                o.description || '',
-            ]).toLowerCase().match(searchValueDebounced.toLowerCase()));
+            .filter(o => {
+                const search = searchValueDebounced.toLowerCase();
+                if (!search) return true;
+
+                const haystack = JSON.stringify([
+                    o.value || '', 
+                    o.label || '', 
+                    // o.caption || '', 
+                    o.description || '',
+                ]).toLowerCase();
+
+                return haystack.includes(search);
+            });
 
         return filtered;
     }, [optionsProp, searchValueDebounced, selected, selectedPending]);


### PR DESCRIPTION
- Replace regex-based search filter in components/select-modal.tsx with a simple case-insensitive substring check so user-entered special characters no longer throw SyntaxError.

- Short-circuit search when the input is empty, ensuring all options render with no search term.

- Keep the original fields (value, label, description) in the searchable payload, preserving behavior while removing regex risks.


https://neotree.atlassian.net/browse/NEOAPP-1176