### PR TITLE
special character search fix

### DIFF
--- a/app/(dashboard)/(scripts)/hooks/use-scripts-table.ts
+++ b/app/(dashboard)/(scripts)/hooks/use-scripts-table.ts
@@ -217,9 +217,9 @@ export function useScriptsTable({ scripts: scriptsParam }: UseScriptsTableParams
         if (value) {
           setSearch((prev) => ({ ...prev, searching: true }))
 
-          const { data: res } = await axios.get<{ data: ScriptsSearchResultsItem[] }>(
-            `/api/scripts/search?searchValue=${value}`,
-          )
+          const { data: res } = await axios.get<{ data: ScriptsSearchResultsItem[] }>("/api/scripts/search", {
+            params: { searchValue: value },
+          })
 
           setSearch((prev) => ({
             value,

--- a/lib/scripts-search.ts
+++ b/lib/scripts-search.ts
@@ -1,6 +1,6 @@
 import * as schema from '@/databases/pg/schema';
 import { ScriptField, ArrayElement } from '@/types';
-import { normalizeSearchTerm } from "@/lib/search";
+import { escapeRegex, normalizeSearchTerm } from "@/lib/search";
 
 type Script = typeof schema.scripts.$inferSelect & {
     isDraft: boolean;
@@ -58,7 +58,8 @@ export function parseScriptsSearchResults({
         return [];
     }
 
-    const pattern = isExactMatch ? `^${normalizedValue}$` : normalizedValue;
+    const escapedSearchValue = escapeRegex(normalizedValue);
+    const pattern = isExactMatch ? `^${escapedSearchValue}$` : escapedSearchValue;
     const searchRegex = new RegExp(pattern);
 
     const resultsMap: Record<string, ScriptsSearchResultsItem> = {};

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,6 +1,11 @@
 const START_QUOTE_CHARS = ['"', '\u201C']
 const END_QUOTE_CHARS = ['"', '\u201D']
 
+/** Escape user input for safe literal use in RegExp constructors. */
+export function escapeRegex(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
 export function normalizeSearchTerm(rawValue: string) {
   const trimmedValue = `${rawValue ?? ""}`.trim()
 


### PR DESCRIPTION
Updated search to handle special characters and avoid truncation.

- Switched scripts search request to axios params so & and other chars aren’t chopped in the URL.
- Escaped user search input before regex construction, ensuring literal matches (works across scripts/screens/diagnoses that use parseScriptsSearchResults).
- Manual check: run the app and search for Age (Days & Hours) in Scripts/Screens/Diagnoses; results should appear instead of “No matches.”