### PR TITLE
diagnoses metadata

### DIFF
--- a/app/(ops)/scripts/[scriptId]/metadata/components/actions.tsx
+++ b/app/(ops)/scripts/[scriptId]/metadata/components/actions.tsx
@@ -56,6 +56,9 @@ export function ScriptMetaActions({ data }: {
                 'Diagnosis Name': string;
                 Key: string;
                 Label: string;
+                'Severity Order': string;
+                Expression: string;
+                'Expression Meaning': string;
                 'Data Type': string;
                 'Value': string;
                 'Value Label': string;
@@ -68,6 +71,9 @@ export function ScriptMetaActions({ data }: {
                     'Diagnosis Name': d.name,
                     Key: d.key,
                     Label: d.name,
+                    'Severity Order': `${d.severityOrder || ''}`,
+                    Expression: `${d.expression || ''}`,
+                    'Expression Meaning': `${d.expressionMeaning || ''}`,
                     'Data Type': 'diagnosis',
                     Value: d.key,
                     'Value Label': d.name,

--- a/databases/queries/scripts/_get_scripts_metadata.ts
+++ b/databases/queries/scripts/_get_scripts_metadata.ts
@@ -38,6 +38,10 @@ export type GetScriptsMetadataResponse = {
             diagnosisId: string;
             name: string;
             key: string;
+            severityOrder?: string | number | null;
+            expression?: string | number | null;
+            expressionMeaning?: string | null;
+            description?: string | null;
             fields: {
                 label: string;
                 key: string;
@@ -167,6 +171,10 @@ export async function _getScriptsMetadata(params?: GetScriptsMetadataParams): Pr
                         diagnosisId: d.diagnosisId,
                         name: d.name,
                         key: d.key || d.name,
+                        severityOrder: d.severityOrder || '',
+                        expression: d.expression || '',
+                        expressionMeaning: d.expressionMeaning || '',
+                        description: d.description || '',
                         fields: [],
                     };
                 }),


### PR DESCRIPTION
Can we get the CDS algorithms metadata on the .CSV export of the script?

https://neotree.atlassian.net/browse/NEOAPP-1193?atlOrigin=eyJpIjoiNzg5ZjU0NWI0M2I1NDE5NWEzZTAwNTdjNTFhYTcxODEiLCJwIjoiaiJ9