### PR TITLE
NEOAPP-1211 Add “Unit” field support for text/number script fields

### DIFF
--- a/app/(dashboard)/(scripts)/components/screens/field.tsx
+++ b/app/(dashboard)/(scripts)/components/screens/field.tsx
@@ -103,6 +103,7 @@ export function Field<P = {}>({ open, field: fieldProp, form, scriptId, disabled
   const defaultValue = watch("defaultValue")
   const values = watch("values")
   const items = watch("items")
+  const unit = watch("unit")
   const valuesOptions = watch("valuesOptions")
   const editable = watch("editable")
 
@@ -313,6 +314,16 @@ export function Field<P = {}>({ open, field: fieldProp, form, scriptId, disabled
                   <Input {...register("label", { disabled })} name="label" error={!disabled && !label} />
                 </div>
               </div>
+
+              {(isTextField || isNumberField) && (
+                <div>
+                  <Label htmlFor="unit">Unit (optional)</Label>
+                  <Input {...register("unit", { disabled })} name="unit" noRing={false} />
+                  <span className="text-xs text-muted-foreground">
+                    Displayed next to the value on summaries and printouts.
+                  </span>
+                </div>
+              )}
 
               <div>
                 <Label htmlFor="refKey">Reference Key</Label>

--- a/app/(dashboard)/(scripts)/hooks/use-field.ts
+++ b/app/(dashboard)/(scripts)/hooks/use-field.ts
@@ -36,6 +36,7 @@ export function useField(field?: ScriptField) {
             minTimeKeyId: field?.minTimeKeyId || '',
             maxTimeKeyId: field?.maxTimeKeyId || '',
             values: field?.values || '',
+            unit: field?.unit || '',
             valuesOptions: field?.valuesOptions || [],
             confidential: field?.confidential || false,
             optional: field?.optional || false,

--- a/databases/types.ts
+++ b/databases/types.ts
@@ -71,6 +71,7 @@ export type ScriptField = {
     minTimeKey: string;
     maxTimeKey: string;
     values: string;
+    unit?: string;
     confidential: boolean;
     optional: boolean;
     printable: boolean;

--- a/types/index.ts
+++ b/types/index.ts
@@ -88,6 +88,7 @@ export type ScriptField = {
     minTimeKeyId?: string;
     maxTimeKeyId?: string;
     values: string;
+    unit?: string;
     valuesOptions: {
         key: string;
         optionKey: string;


### PR DESCRIPTION
# Ticket [NEOAPP-1211](https://neotree.atlassian.net/browse/NEOAPP-1211)


Extends script field configuration to allow authors to specify a unit of measurement for number/text fields when designing scripts and data capture flows.

Units are necessary for clinical accuracy and correct interpretation of numeric values. Adding unit support at the script level allows the mobile app to render the correct unit during printing.

Key Changes

Added unit property to all relevant ScriptField TypeScript types.

Initialized unit in field creation defaults.

Updated the Field Editor UI to include:

“Unit (optional)” input for text and number field types.

Ensures unit metadata is available to downstream consumers (mobile app, PDF renderer, etc.).