### PR TITLE
Prevent user from being able to replace datakeys

### DIFF
--- a/components/search-and-replace-modal.tsx
+++ b/components/search-and-replace-modal.tsx
@@ -99,7 +99,12 @@ function getReplaceItems({
             });
         });
 
-    return items.filter(item => !!item.matches.length);
+    return items
+        .filter(item => !!item.matches.length)
+        .map(item => ({
+            ...item,
+            matches: item.matches.filter(match => ['key', 'field_key', 'field_id'].includes(match.field)),
+        }));
 }
 
 function sanitizeSearchValue(searchValue = '') {
@@ -434,8 +439,6 @@ export function SearchAndReplaceModal(props: Props) {
 
                                 {replaceItem.matches.map((match, matchIndex) => {
                                     const key = replaceItem.id + `_match${matchIndex}`;
-
-                                    if (['key', 'field_key', 'field_id'].includes(match.field)) return null;
 
                                     return (
                                         <Card

--- a/components/search-and-replace-modal.tsx
+++ b/components/search-and-replace-modal.tsx
@@ -435,7 +435,7 @@ export function SearchAndReplaceModal(props: Props) {
                                 {replaceItem.matches.map((match, matchIndex) => {
                                     const key = replaceItem.id + `_match${matchIndex}`;
 
-                                    if (match.field === 'key') return null;
+                                    if (['key', 'field_key', 'field_id'].includes(match.field)) return null;
 
                                     return (
                                         <Card

--- a/components/search-and-replace-modal.tsx
+++ b/components/search-and-replace-modal.tsx
@@ -103,7 +103,7 @@ function getReplaceItems({
         .filter(item => !!item.matches.length)
         .map(item => ({
             ...item,
-            matches: item.matches.filter(match => ['key', 'field_key', 'field_id'].includes(match.field)),
+            matches: item.matches.filter(match => !['key', 'field_key', 'field_id', 'field_item_key', 'field_item_id'].includes(match.field)),
         }));
 }
 


### PR DESCRIPTION
https://neotree.atlassian.net/browse/NEOAPP-1151:

Prevent user from being able to replace datakeys - this should only be able to be done in the datakey library by super users