### PR TITLE
Changelogs: server-side summaries, rollback UX, and optional soft-delete on rollback

### DIFF
--- a/app/(dashboard)/changelogs/components/changelogs-table-header.tsx
+++ b/app/(dashboard)/changelogs/components/changelogs-table-header.tsx
@@ -10,11 +10,13 @@ type Props = {
   entityType: string
   action: string
   isActiveOnly: boolean
+  applyFiltersToCounts: boolean
   sort: string
   sortOptions: { value: string; label: string }[]
   setEntityType: (value: string) => void
   setAction: (value: string) => void
   setIsActiveOnly: (value: boolean) => void
+  setApplyFiltersToCounts: (value: boolean) => void
   setSort: (value: string) => void
   clearFilters: () => void
   loading: boolean
@@ -35,11 +37,13 @@ export function ChangelogsTableHeader({
   entityType,
   action,
   isActiveOnly,
+  applyFiltersToCounts,
   sort,
   sortOptions,
   setEntityType,
   setAction,
   setIsActiveOnly,
+  setApplyFiltersToCounts,
   setSort,
   clearFilters,
   loading,
@@ -113,6 +117,18 @@ export function ChangelogsTableHeader({
                   className="rounded"
                 />
                 <span className="text-sm whitespace-nowrap">Active only</span>
+              </label>
+            </div>
+
+            <div className="flex items-center">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={applyFiltersToCounts}
+                  onChange={(e) => setApplyFiltersToCounts(e.target.checked)}
+                  className="rounded"
+                />
+                <span className="text-sm whitespace-nowrap">Filter counts</span>
               </label>
             </div>
 

--- a/app/(dashboard)/changelogs/components/changelogs-table.tsx
+++ b/app/(dashboard)/changelogs/components/changelogs-table.tsx
@@ -161,6 +161,7 @@ export function ChangelogsTable(props: Props) {
   const [rollbacking, setRollbacking] = useState<number | null>(null)
   const [pendingRollbackEntry, setPendingRollbackEntry] = useState<DataVersionSummary | null>(null)
   const [showEntityDetails, setShowEntityDetails] = useState(false)
+  const [softDeleteCreated, setSoftDeleteCreated] = useState(false)
 
   useEffect(() => {
     if (pendingRollbackEntry) {
@@ -233,6 +234,7 @@ export function ChangelogsTable(props: Props) {
       const res = await axios.post("/api/changelogs/rollback-data-version", {
         dataVersion,
         changeReason: `Rollback release v${dataVersion} to v${dataVersion - 1}`,
+        createdEntityPolicy: softDeleteCreated ? "soft_delete" : "keep",
       })
 
       if (res.data?.errors?.length) {
@@ -254,6 +256,7 @@ export function ChangelogsTable(props: Props) {
     } finally {
       setRollbacking(null)
       setPendingRollbackEntry(null)
+      setSoftDeleteCreated(false)
     }
   }
 
@@ -517,6 +520,7 @@ export function ChangelogsTable(props: Props) {
           if (!open) {
             setPendingRollbackEntry(null)
             setShowEntityDetails(false)
+            setSoftDeleteCreated(false)
           }
         }}
       >
@@ -559,6 +563,21 @@ export function ChangelogsTable(props: Props) {
                           )}
                         </div>
                       )}
+                    </div>
+                    <div className="pt-1">
+                      <label className="flex items-center gap-2 text-sm cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={softDeleteCreated}
+                          onChange={(event) => setSoftDeleteCreated(event.target.checked)}
+                          className="rounded"
+                          disabled={rollbacking !== null}
+                        />
+                        <span>Soft delete items created in this release</span>
+                      </label>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Newly created entities with no prior snapshot will be marked deleted instead of kept.
+                      </p>
                     </div>
                   </>
                 )}

--- a/app/(dashboard)/changelogs/components/changelogs-table.tsx
+++ b/app/(dashboard)/changelogs/components/changelogs-table.tsx
@@ -310,7 +310,7 @@ export function ChangelogsTable(props: Props) {
 
   return (
     <>
-      {loading && <Loader overlay />}
+      {(loading || rollbacking !== null) && <Loader overlay />}
 
       <div className="flex flex-col gap-y-4">
         <ChangelogsTableHeader
@@ -531,6 +531,9 @@ export function ChangelogsTable(props: Props) {
                       You are about to publish a rollback for release v{pendingRollbackEntry.dataVersion}, restoring the state
                       of the previous release. This will publish a new release v{pendingRollbackEntry.dataVersion + 1}.
                     </p>
+                    {rollbacking !== null && (
+                      <p className="text-sm text-muted-foreground">Rollback in progress. Please wait...</p>
+                    )}
                     <div>
                       <p className="font-medium text-foreground mb-1">Entities affected:</p>
                       {renderEntityImpactList(pendingRollbackEntry)}

--- a/app/(dashboard)/changelogs/hooks/use-changelogs-table.ts
+++ b/app/(dashboard)/changelogs/hooks/use-changelogs-table.ts
@@ -206,10 +206,8 @@ export function useChangelogsTable({
 
   return {
     dataVersions,
-    totalDataVersions: filteredSummaries.length,
-    loading,
-    dataVersions,
     totalDataVersions,
+    loading,
     searchValue,
     entityType,
     action,

--- a/app/(dashboard)/changelogs/page.tsx
+++ b/app/(dashboard)/changelogs/page.tsx
@@ -2,15 +2,16 @@ import { Title } from "@/components/title"
 import { Content } from "@/components/content"
 import { Card, CardContent } from "@/components/ui/card"
 import { ChangelogManagement } from "./components"
-import { getChangeLogs } from "@/app/actions/change-logs"
+import { getDataVersionSummaries } from "@/app/actions/change-logs"
 import { getAuthenticatedUser } from "@/app/actions/get-authenticated-user"
 
 export const dynamic = "force-dynamic"
 
 export default async function ChangelogsPage() {
-  const changelogs = await getChangeLogs({
-    limit: 500,
-    sortBy: "dateOfChange",
+  const summaries = await getDataVersionSummaries({
+    limit: 25,
+    offset: 0,
+    sortBy: "publishedAt",
     sortOrder: "desc",
   })
   const currentUser = await getAuthenticatedUser()
@@ -23,7 +24,12 @@ export default async function ChangelogsPage() {
       <Content>
         <Card className="mb-20">
           <CardContent className="p-0">
-            <ChangelogManagement initialChangelogs={changelogs.data} isSuperUser={isSuperUser} />
+            <ChangelogManagement
+              initialSummaries={summaries.data}
+              initialTotal={summaries.total}
+              initialLatestDataVersion={summaries.latestDataVersion ?? null}
+              isSuperUser={isSuperUser}
+            />
           </CardContent>
         </Card>
       </Content>

--- a/app/actions/change-logs.ts
+++ b/app/actions/change-logs.ts
@@ -128,6 +128,16 @@ export const countEntityVersions: typeof queries._countEntityVersions = async (.
   }
 }
 
+export const getDataVersionSummaries: typeof queries._getDataVersionSummaries = async (...args) => {
+  try {
+    await isAllowed()
+    return await queries._getDataVersionSummaries(...args)
+  } catch (e: any) {
+    logger.error("getDataVersionSummaries ERROR", e.message)
+    return { errors: [e.message], data: [], total: 0 }
+  }
+}
+
 export const searchChangeLogs: typeof queries.SearchChangeLogs._searchChangeLogs = async (...args) => {
   try {
     await isAllowed()

--- a/app/api/changelogs/summaries/route.ts
+++ b/app/api/changelogs/summaries/route.ts
@@ -1,0 +1,26 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { getDataVersionSummaries } from "@/app/actions/change-logs"
+import logger from "@/lib/logger"
+import { isAuthenticated } from "@/app/actions/is-authenticated"
+
+export async function POST(req: NextRequest) {
+  try {
+    const isAuthorised = await isAuthenticated()
+
+    if (!isAuthorised.yes) return NextResponse.json({ errors: ["Unauthorised"] }, { status: 401 })
+
+    const body = await req.json()
+    const limit = Math.max(1, Math.min(Number(body?.limit) || 25, 100))
+    const offset = Math.max(0, Number(body?.offset) || 0)
+
+    const data = await getDataVersionSummaries({
+      ...body,
+      limit,
+      offset,
+    })
+    return NextResponse.json(data)
+  } catch (e: any) {
+    logger.log("/api/changelogs/summaries", e)
+    return NextResponse.json({ errors: [e.message] }, { status: 500 })
+  }
+}

--- a/databases/mutations/changelogs/_rollback-data-version.ts
+++ b/databases/mutations/changelogs/_rollback-data-version.ts
@@ -22,6 +22,7 @@ export type RollbackDataVersionParams = {
   dataVersion?: number
   userId: string
   changeReason?: string
+  createdEntityPolicy?: "keep" | "soft_delete"
 }
 
 export type RollbackDataVersionResponse = {
@@ -303,6 +304,7 @@ export async function _rollbackDataVersion({
   dataVersion: requestedDataVersion,
   userId,
   changeReason,
+  createdEntityPolicy = "keep",
 }: RollbackDataVersionParams): Promise<RollbackDataVersionResponse> {
   const response: RollbackDataVersionResponse = { success: false }
   let restoredVersion: number | undefined
@@ -381,6 +383,8 @@ export async function _rollbackDataVersion({
       const scriptChanges = currentChanges.filter((c) => c.entityType === "script")
       const nonScriptChanges = currentChanges.filter((c) => c.entityType !== "script")
 
+      const shouldSoftDeleteCreated = createdEntityPolicy === "soft_delete"
+
       for (const scriptChange of scriptChanges) {
         const binding = ENTITY_BINDINGS[scriptChange.entityType]
         if (!binding) throw new Error(`Unsupported entity type ${scriptChange.entityType}`)
@@ -389,8 +393,18 @@ export async function _rollbackDataVersion({
         const effectiveScriptTarget = await findPreviousChangeLog(tx, scriptChange, currentDataVersion)
     if (!effectiveScriptTarget.fullSnapshot) throw new Error(`Missing previous script snapshot ${scriptChange.entityId}`)
 
-        const plan: { current: typeof changeLogs.$inferSelect; target: typeof changeLogs.$inferSelect; binding: VersionedEntityBinding }[] = []
-        plan.push({ current: scriptChange, target: effectiveScriptTarget, binding })
+        const plan: {
+          current: typeof changeLogs.$inferSelect
+          target: typeof changeLogs.$inferSelect
+          binding: VersionedEntityBinding
+          createdInCurrentVersion: boolean
+        }[] = []
+        plan.push({
+          current: scriptChange,
+          target: effectiveScriptTarget,
+          binding,
+          createdInCurrentVersion: effectiveScriptTarget.dataVersion === currentDataVersion,
+        })
 
         const childTypes: (typeof changeLogs.$inferSelect)["entityType"][] = ["screen", "diagnosis"]
         for (const childType of childTypes) {
@@ -414,16 +428,25 @@ export async function _rollbackDataVersion({
             if (!effectiveChildTarget || !effectiveChildTarget.fullSnapshot) {
               throw new Error(`Missing previous snapshot for child entity ${child.entityId}`)
             }
-            plan.push({ current: child, target: effectiveChildTarget, binding: childBinding })
+            plan.push({
+              current: child,
+              target: effectiveChildTarget,
+              binding: childBinding,
+              createdInCurrentVersion: !targetChild || targetChild.dataVersion === currentDataVersion,
+            })
           }
         }
 
         // Apply plan atomically
-        for (const { current, target, binding } of plan) {
+        for (const { current, target, binding, createdInCurrentVersion } of plan) {
           const effectiveTarget = target ?? current
           const description = `Rollback release v${currentDataVersion} -> v${targetDataVersion} (state of v${previousDataVersion})`
           const targetSnapshot = normalizeSnapshot(effectiveTarget.fullSnapshot)
           const currentSnapshot = normalizeSnapshot(current.fullSnapshot)
+          const shouldSoftDelete = shouldSoftDeleteCreated && createdInCurrentVersion
+          if (shouldSoftDelete) {
+            targetSnapshot.deletedAt = new Date().toISOString()
+          }
           const rollbackChangeLog: SaveChangeLogData = {
             entityId: current.entityId,
             entityType: current.entityType,
@@ -495,6 +518,11 @@ export async function _rollbackDataVersion({
         const description = `Rollback release v${currentDataVersion} -> v${targetDataVersion} (state of v${previousDataVersion})`
         const targetSnapshot = normalizeSnapshot(effectiveTarget.fullSnapshot)
         const currentSnapshot = normalizeSnapshot(current.fullSnapshot)
+        const createdInCurrentVersion = !target || target.dataVersion === currentDataVersion
+        const shouldSoftDelete = shouldSoftDeleteCreated && createdInCurrentVersion
+        if (shouldSoftDelete) {
+          targetSnapshot.deletedAt = new Date().toISOString()
+        }
         const rollbackChangeLog: SaveChangeLogData = {
           entityId: current.entityId,
           entityType: current.entityType,

--- a/databases/mutations/changelogs/_rollback-data-version.ts
+++ b/databases/mutations/changelogs/_rollback-data-version.ts
@@ -453,6 +453,7 @@ export async function _rollbackDataVersion({
             drugsLibraryItemId: current.drugsLibraryItemId,
             dataKeyId: current.dataKeyId,
             aliasId: current.aliasId,
+            hospitalId: current.entityType === "hospital" ? current.entityId : undefined,
           }
 
           const saved = await _saveChangeLog({ data: rollbackChangeLog, client: tx })
@@ -523,6 +524,7 @@ export async function _rollbackDataVersion({
           drugsLibraryItemId: current.drugsLibraryItemId,
           dataKeyId: current.dataKeyId,
           aliasId: current.aliasId,
+          hospitalId: current.entityType === "hospital" ? current.entityId : undefined,
         }
 
         const saved = await _saveChangeLog({ data: rollbackChangeLog, client: tx })

--- a/databases/pg/migrations/0007_fantastic_shadow_king.sql
+++ b/databases/pg/migrations/0007_fantastic_shadow_king.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "nt_screens" ADD COLUMN "print_display_columns" integer DEFAULT 2 NOT NULL;

--- a/databases/pg/migrations/meta/0007_snapshot.json
+++ b/databases/pg/migrations/meta/0007_snapshot.json
@@ -1,0 +1,4994 @@
+{
+  "id": "17cb0d59-919e-42f0-92a5-66fe0fc18ed4",
+  "prevId": "9c90d66b-1c6d-4da1-93dc-7d116b8af5c3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.nt_api_keys": {
+      "name": "nt_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_api_keys_api_key_id_unique": {
+          "name": "nt_api_keys_api_key_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "api_key_id"
+          ]
+        },
+        "nt_api_keys_api_key_unique": {
+          "name": "nt_api_keys_api_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "api_key"
+          ]
+        }
+      }
+    },
+    "public.nt_auth_clients": {
+      "name": "nt_auth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "client_token": {
+          "name": "client_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_auth_clients_user_id_nt_users_user_id_fk": {
+          "name": "nt_auth_clients_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_auth_clients",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_auth_clients_client_id_unique": {
+          "name": "nt_auth_clients_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        },
+        "nt_auth_clients_client_token_unique": {
+          "name": "nt_auth_clients_client_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_token"
+          ]
+        }
+      }
+    },
+    "public.nt_change_logs": {
+      "name": "nt_change_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "change_log_id": {
+          "name": "change_log_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "change_log_entity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_version": {
+          "name": "parent_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_from_version": {
+          "name": "merged_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_id": {
+          "name": "screen_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosis_id": {
+          "name": "diagnosis_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_key_id": {
+          "name": "config_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hospital_id": {
+          "name": "hospital_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drugs_library_item_id": {
+          "name": "drugs_library_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_key_id": {
+          "name": "data_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "change_log_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "full_snapshot": {
+          "name": "full_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_snapshot": {
+          "name": "previous_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "snapshot_hash": {
+          "name": "snapshot_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "change_reason": {
+          "name": "change_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_change": {
+          "name": "date_of_change",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "data_version": {
+          "name": "data_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "unique_version_per_entity": {
+          "name": "unique_version_per_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "active_version_index": {
+          "name": "active_version_index",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_logs_entity_index": {
+          "name": "change_logs_entity_index",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "version_chain_index": {
+          "name": "version_chain_index",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_logs_user_index": {
+          "name": "change_logs_user_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_logs_date_index": {
+          "name": "change_logs_date_index",
+          "columns": [
+            {
+              "expression": "date_of_change",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_logs_data_version_index": {
+          "name": "change_logs_data_version_index",
+          "columns": [
+            {
+              "expression": "data_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nt_change_logs_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_change_logs_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_change_logs",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "nt_change_logs_screen_id_nt_screens_screen_id_fk": {
+          "name": "nt_change_logs_screen_id_nt_screens_screen_id_fk",
+          "tableFrom": "nt_change_logs",
+          "tableTo": "nt_screens",
+          "columnsFrom": [
+            "screen_id"
+          ],
+          "columnsTo": [
+            "screen_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "nt_change_logs_diagnosis_id_nt_diagnoses_diagnosis_id_fk": {
+          "name": "nt_change_logs_diagnosis_id_nt_diagnoses_diagnosis_id_fk",
+          "tableFrom": "nt_change_logs",
+          "tableTo": "nt_diagnoses",
+          "columnsFrom": [
+            "diagnosis_id"
+          ],
+          "columnsTo": [
+            "diagnosis_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "nt_change_logs_config_key_id_nt_config_keys_config_key_id_fk": {
+          "name": "nt_change_logs_config_key_id_nt_config_keys_config_key_id_fk",
+          "tableFrom": "nt_change_logs",
+          "tableTo": "nt_config_keys",
+          "columnsFrom": [
+            "config_key_id"
+          ],
+          "columnsTo": [
+            "config_key_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "nt_change_logs_hospital_id_nt_hospitals_hospital_id_fk": {
+          "name": "nt_change_logs_hospital_id_nt_hospitals_hospital_id_fk",
+          "tableFrom": "nt_change_logs",
+          "tableTo": "nt_hospitals",
+          "columnsFrom": [
+            "hospital_id"
+          ],
+          "columnsTo": [
+            "hospital_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "nt_change_logs_drugs_library_item_id_nt_drugs_library_item_id_fk": {
+          "name": "nt_change_logs_drugs_library_item_id_nt_drugs_library_item_id_fk",
+          "tableFrom": "nt_change_logs",
+          "tableTo": "nt_drugs_library",
+          "columnsFrom": [
+            "drugs_library_item_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "nt_change_logs_data_key_id_nt_data_keys_uuid_fk": {
+          "name": "nt_change_logs_data_key_id_nt_data_keys_uuid_fk",
+          "tableFrom": "nt_change_logs",
+          "tableTo": "nt_data_keys",
+          "columnsFrom": [
+            "data_key_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "nt_change_logs_alias_id_nt_aliases_uuid_fk": {
+          "name": "nt_change_logs_alias_id_nt_aliases_uuid_fk",
+          "tableFrom": "nt_change_logs",
+          "tableTo": "nt_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "nt_change_logs_user_id_nt_users_user_id_fk": {
+          "name": "nt_change_logs_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_change_logs",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_change_logs_change_log_id_unique": {
+          "name": "nt_change_logs_change_log_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "change_log_id"
+          ]
+        }
+      }
+    },
+    "public.nt_config_keys": {
+      "name": "nt_config_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_key_id": {
+          "name": "config_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "old_config_key_id": {
+          "name": "old_config_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'editor'"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"fontSize\":{},\"fontWeight\":{},\"fontStyle\":{},\"textColor\":{},\"backgroundColor\":{},\"highlight\":{}}'"
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "config_keys_search_index": {
+          "name": "config_keys_search_index",
+          "columns": [
+            {
+              "expression": "(\n                    to_tsvector('english', \"key\") ||\n                    to_tsvector('english', \"label\") ||\n                    to_tsvector('english', \"summary\")\n                )",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_config_keys_config_key_id_unique": {
+          "name": "nt_config_keys_config_key_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "config_key_id"
+          ]
+        },
+        "nt_config_keys_old_config_key_id_unique": {
+          "name": "nt_config_keys_old_config_key_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "old_config_key_id"
+          ]
+        },
+        "nt_config_keys_key_unique": {
+          "name": "nt_config_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        },
+        "nt_config_keys_label_unique": {
+          "name": "nt_config_keys_label_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label"
+          ]
+        }
+      }
+    },
+    "public.nt_config_keys_drafts": {
+      "name": "nt_config_keys_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_key_draft_id": {
+          "name": "config_key_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "config_key_id": {
+          "name": "config_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_config_keys_drafts_config_key_id_nt_config_keys_config_key_id_fk": {
+          "name": "nt_config_keys_drafts_config_key_id_nt_config_keys_config_key_id_fk",
+          "tableFrom": "nt_config_keys_drafts",
+          "tableTo": "nt_config_keys",
+          "columnsFrom": [
+            "config_key_id"
+          ],
+          "columnsTo": [
+            "config_key_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_config_keys_drafts_created_by_user_id_nt_users_user_id_fk": {
+          "name": "nt_config_keys_drafts_created_by_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_config_keys_drafts",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_config_keys_drafts_config_key_draft_id_unique": {
+          "name": "nt_config_keys_drafts_config_key_draft_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "config_key_draft_id"
+          ]
+        }
+      }
+    },
+    "public.nt_config_keys_history": {
+      "name": "nt_config_keys_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_key_id": {
+          "name": "config_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restore_key": {
+          "name": "restore_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_config_keys_history_config_key_id_nt_config_keys_config_key_id_fk": {
+          "name": "nt_config_keys_history_config_key_id_nt_config_keys_config_key_id_fk",
+          "tableFrom": "nt_config_keys_history",
+          "tableTo": "nt_config_keys",
+          "columnsFrom": [
+            "config_key_id"
+          ],
+          "columnsTo": [
+            "config_key_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nt_devices": {
+      "name": "nt_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_hash": {
+          "name": "device_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_devices_device_id_unique": {
+          "name": "nt_devices_device_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_id"
+          ]
+        },
+        "nt_devices_device_hash_unique": {
+          "name": "nt_devices_device_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_hash"
+          ]
+        }
+      }
+    },
+    "public.nt_diagnoses": {
+      "name": "nt_diagnoses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "diagnosis_id": {
+          "name": "diagnosis_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "old_diagnosis_id": {
+          "name": "old_diagnosis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_script_id": {
+          "name": "old_script_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'editor'"
+        },
+        "expression": {
+          "name": "expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "severity_order": {
+          "name": "severity_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expression_meaning": {
+          "name": "expression_meaning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "symptoms": {
+          "name": "symptoms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "text1": {
+          "name": "text1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "text2": {
+          "name": "text2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "text3": {
+          "name": "text3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "image1": {
+          "name": "image1",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image2": {
+          "name": "image2",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image3": {
+          "name": "image3",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"fontSize\":{},\"fontWeight\":{},\"fontStyle\":{},\"textColor\":{},\"backgroundColor\":{},\"highlight\":{}}'"
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "diagnoses_search_index": {
+          "name": "diagnoses_search_index",
+          "columns": [
+            {
+              "expression": "(\n                    to_tsvector('english', \"name\")\n                )",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nt_diagnoses_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_diagnoses_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_diagnoses",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_diagnoses_diagnosis_id_unique": {
+          "name": "nt_diagnoses_diagnosis_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "diagnosis_id"
+          ]
+        },
+        "nt_diagnoses_old_diagnosis_id_unique": {
+          "name": "nt_diagnoses_old_diagnosis_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "old_diagnosis_id"
+          ]
+        }
+      }
+    },
+    "public.nt_diagnoses_drafts": {
+      "name": "nt_diagnoses_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "diagnosis_draft_id": {
+          "name": "diagnosis_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "diagnosis_id": {
+          "name": "diagnosis_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "script_draft_id": {
+          "name": "script_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_diagnoses_drafts_diagnosis_id_nt_diagnoses_diagnosis_id_fk": {
+          "name": "nt_diagnoses_drafts_diagnosis_id_nt_diagnoses_diagnosis_id_fk",
+          "tableFrom": "nt_diagnoses_drafts",
+          "tableTo": "nt_diagnoses",
+          "columnsFrom": [
+            "diagnosis_id"
+          ],
+          "columnsTo": [
+            "diagnosis_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_diagnoses_drafts_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_diagnoses_drafts_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_diagnoses_drafts",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_diagnoses_drafts_script_draft_id_nt_scripts_drafts_script_draft_id_fk": {
+          "name": "nt_diagnoses_drafts_script_draft_id_nt_scripts_drafts_script_draft_id_fk",
+          "tableFrom": "nt_diagnoses_drafts",
+          "tableTo": "nt_scripts_drafts",
+          "columnsFrom": [
+            "script_draft_id"
+          ],
+          "columnsTo": [
+            "script_draft_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_diagnoses_drafts_created_by_user_id_nt_users_user_id_fk": {
+          "name": "nt_diagnoses_drafts_created_by_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_diagnoses_drafts",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_diagnoses_drafts_diagnosis_draft_id_unique": {
+          "name": "nt_diagnoses_drafts_diagnosis_draft_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "diagnosis_draft_id"
+          ]
+        }
+      }
+    },
+    "public.nt_diagnoses_history": {
+      "name": "nt_diagnoses_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diagnosis_id": {
+          "name": "diagnosis_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restore_key": {
+          "name": "restore_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_diagnoses_history_diagnosis_id_nt_diagnoses_diagnosis_id_fk": {
+          "name": "nt_diagnoses_history_diagnosis_id_nt_diagnoses_diagnosis_id_fk",
+          "tableFrom": "nt_diagnoses_history",
+          "tableTo": "nt_diagnoses",
+          "columnsFrom": [
+            "diagnosis_id"
+          ],
+          "columnsTo": [
+            "diagnosis_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_diagnoses_history_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_diagnoses_history_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_diagnoses_history",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nt_drugs_library": {
+      "name": "nt_drugs_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "drug_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'drug'"
+        },
+        "drug": {
+          "name": "drug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "min_gestation": {
+          "name": "min_gestation",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_gestation": {
+          "name": "max_gestation",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_weight": {
+          "name": "min_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_weight": {
+          "name": "max_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_age": {
+          "name": "min_age",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_age": {
+          "name": "max_age",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_feed": {
+          "name": "hourly_feed",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_feed_divider": {
+          "name": "hourly_feed_divider",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dosage_multiplier": {
+          "name": "dosage_multiplier",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_life": {
+          "name": "day_of_life",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "dosage_text": {
+          "name": "dosage_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "management_text": {
+          "name": "management_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "gestation_key": {
+          "name": "gestation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "weight_key": {
+          "name": "weight_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "diagnosis_key": {
+          "name": "diagnosis_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "age_key": {
+          "name": "age_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "age_key_id": {
+          "name": "age_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "gestation_key_id": {
+          "name": "gestation_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "weight_key_id": {
+          "name": "weight_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "diagnosis_key_id": {
+          "name": "diagnosis_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "administration_frequency": {
+          "name": "administration_frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "drug_unit": {
+          "name": "drug_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "route_of_administration": {
+          "name": "route_of_administration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "calculator_condition": {
+          "name": "calculator_condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "validation_type": {
+          "name": "validation_type",
+          "type": "dff_item_validation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_drugs_library_item_id_unique": {
+          "name": "nt_drugs_library_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_id"
+          ]
+        },
+        "nt_drugs_library_key_unique": {
+          "name": "nt_drugs_library_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      }
+    },
+    "public.nt_drugs_library_drafts": {
+      "name": "nt_drugs_library_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "item_draft_id": {
+          "name": "item_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "drug_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'drug'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_drugs_library_drafts_item_id_nt_drugs_library_item_id_fk": {
+          "name": "nt_drugs_library_drafts_item_id_nt_drugs_library_item_id_fk",
+          "tableFrom": "nt_drugs_library_drafts",
+          "tableTo": "nt_drugs_library",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_drugs_library_drafts_created_by_user_id_nt_users_user_id_fk": {
+          "name": "nt_drugs_library_drafts_created_by_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_drugs_library_drafts",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_drugs_library_drafts_item_draft_id_unique": {
+          "name": "nt_drugs_library_drafts_item_draft_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_draft_id"
+          ]
+        }
+      }
+    },
+    "public.nt_drugs_library_history": {
+      "name": "nt_drugs_library_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restore_key": {
+          "name": "restore_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_drugs_library_history_item_id_nt_drugs_library_item_id_fk": {
+          "name": "nt_drugs_library_history_item_id_nt_drugs_library_item_id_fk",
+          "tableFrom": "nt_drugs_library_history",
+          "tableTo": "nt_drugs_library",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nt_editor_info": {
+      "name": "nt_editor_info",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data_version": {
+          "name": "data_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_publish_date": {
+          "name": "last_publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_data_keys_sync_date": {
+          "name": "last_data_keys_sync_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nt_email_templates": {
+      "name": "nt_email_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_email_templates_template_id_unique": {
+          "name": "nt_email_templates_template_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "template_id"
+          ]
+        },
+        "nt_email_templates_name_unique": {
+          "name": "nt_email_templates_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.nt_files": {
+      "name": "nt_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_files_owner_id_nt_users_user_id_fk": {
+          "name": "nt_files_owner_id_nt_users_user_id_fk",
+          "tableFrom": "nt_files",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_files_file_id_unique": {
+          "name": "nt_files_file_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "file_id"
+          ]
+        }
+      }
+    },
+    "public.nt_files_chunks": {
+      "name": "nt_files_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chunk_id": {
+          "name": "chunk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_files_chunks_file_id_nt_files_file_id_fk": {
+          "name": "nt_files_chunks_file_id_nt_files_file_id_fk",
+          "tableFrom": "nt_files_chunks",
+          "tableTo": "nt_files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "file_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_files_chunks_chunk_id_unique": {
+          "name": "nt_files_chunks_chunk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chunk_id"
+          ]
+        }
+      }
+    },
+    "public.nt_hospitals": {
+      "name": "nt_hospitals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hospital_id": {
+          "name": "hospital_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "old_hospital_id": {
+          "name": "old_hospital_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hospitals_search_index": {
+          "name": "hospitals_search_index",
+          "columns": [
+            {
+              "expression": "(\n                    to_tsvector('english', \"name\")\n                )",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_hospitals_hospital_id_unique": {
+          "name": "nt_hospitals_hospital_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hospital_id"
+          ]
+        },
+        "nt_hospitals_old_hospital_id_unique": {
+          "name": "nt_hospitals_old_hospital_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "old_hospital_id"
+          ]
+        },
+        "nt_hospitals_name_unique": {
+          "name": "nt_hospitals_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.nt_hospitals_drafts": {
+      "name": "nt_hospitals_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hospital_draft_id": {
+          "name": "hospital_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "hospital_id": {
+          "name": "hospital_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_hospitals_drafts_hospital_id_nt_hospitals_hospital_id_fk": {
+          "name": "nt_hospitals_drafts_hospital_id_nt_hospitals_hospital_id_fk",
+          "tableFrom": "nt_hospitals_drafts",
+          "tableTo": "nt_hospitals",
+          "columnsFrom": [
+            "hospital_id"
+          ],
+          "columnsTo": [
+            "hospital_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_hospitals_drafts_created_by_user_id_nt_users_user_id_fk": {
+          "name": "nt_hospitals_drafts_created_by_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_hospitals_drafts",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_hospitals_drafts_hospital_draft_id_unique": {
+          "name": "nt_hospitals_drafts_hospital_draft_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hospital_draft_id"
+          ]
+        }
+      }
+    },
+    "public.nt_hospitals_history": {
+      "name": "nt_hospitals_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hospital_id": {
+          "name": "hospital_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restore_key": {
+          "name": "restore_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_hospitals_history_hospital_id_nt_hospitals_hospital_id_fk": {
+          "name": "nt_hospitals_history_hospital_id_nt_hospitals_hospital_id_fk",
+          "tableFrom": "nt_hospitals_history",
+          "tableTo": "nt_hospitals",
+          "columnsFrom": [
+            "hospital_id"
+          ],
+          "columnsTo": [
+            "hospital_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nt_languages": {
+      "name": "nt_languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iso": {
+          "name": "iso",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_languages_name_unique": {
+          "name": "nt_languages_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "nt_languages_iso_unique": {
+          "name": "nt_languages_iso_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "iso"
+          ]
+        }
+      }
+    },
+    "public.nt_mailer_settings": {
+      "name": "nt_mailer_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "setting_id": {
+          "name": "setting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "mailer_service",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_username": {
+          "name": "auth_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_password": {
+          "name": "auth_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption": {
+          "name": "encryption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "secure": {
+          "name": "secure",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_mailer_settings_setting_id_unique": {
+          "name": "nt_mailer_settings_setting_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "setting_id"
+          ]
+        },
+        "nt_mailer_settings_name_unique": {
+          "name": "nt_mailer_settings_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.nt_pending_deletion": {
+      "name": "nt_pending_deletion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_id": {
+          "name": "screen_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_script_id": {
+          "name": "screen_script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosis_id": {
+          "name": "diagnosis_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosis_script_id": {
+          "name": "diagnosis_script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_key_id": {
+          "name": "config_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hospital_id": {
+          "name": "hospital_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drugs_library_item_id": {
+          "name": "drugs_library_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "script_draft_id": {
+          "name": "script_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_draft_id": {
+          "name": "screen_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosis_draft_id": {
+          "name": "diagnosis_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_key_draft_id": {
+          "name": "config_key_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hospital_draft_id": {
+          "name": "hospital_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drugs_library_item_draft_id": {
+          "name": "drugs_library_item_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_key_id": {
+          "name": "data_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_key_draft_id": {
+          "name": "data_key_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_pending_deletion_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_pending_deletion_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_screen_id_nt_screens_screen_id_fk": {
+          "name": "nt_pending_deletion_screen_id_nt_screens_screen_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_screens",
+          "columnsFrom": [
+            "screen_id"
+          ],
+          "columnsTo": [
+            "screen_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_screen_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_pending_deletion_screen_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "screen_script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_diagnosis_id_nt_diagnoses_diagnosis_id_fk": {
+          "name": "nt_pending_deletion_diagnosis_id_nt_diagnoses_diagnosis_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_diagnoses",
+          "columnsFrom": [
+            "diagnosis_id"
+          ],
+          "columnsTo": [
+            "diagnosis_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_diagnosis_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_pending_deletion_diagnosis_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "diagnosis_script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_config_key_id_nt_config_keys_config_key_id_fk": {
+          "name": "nt_pending_deletion_config_key_id_nt_config_keys_config_key_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_config_keys",
+          "columnsFrom": [
+            "config_key_id"
+          ],
+          "columnsTo": [
+            "config_key_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_hospital_id_nt_hospitals_hospital_id_fk": {
+          "name": "nt_pending_deletion_hospital_id_nt_hospitals_hospital_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_hospitals",
+          "columnsFrom": [
+            "hospital_id"
+          ],
+          "columnsTo": [
+            "hospital_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_drugs_library_item_id_nt_drugs_library_item_id_fk": {
+          "name": "nt_pending_deletion_drugs_library_item_id_nt_drugs_library_item_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_drugs_library",
+          "columnsFrom": [
+            "drugs_library_item_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_script_draft_id_nt_scripts_drafts_script_draft_id_fk": {
+          "name": "nt_pending_deletion_script_draft_id_nt_scripts_drafts_script_draft_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_scripts_drafts",
+          "columnsFrom": [
+            "script_draft_id"
+          ],
+          "columnsTo": [
+            "script_draft_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_screen_draft_id_nt_screens_drafts_screen_draft_id_fk": {
+          "name": "nt_pending_deletion_screen_draft_id_nt_screens_drafts_screen_draft_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_screens_drafts",
+          "columnsFrom": [
+            "screen_draft_id"
+          ],
+          "columnsTo": [
+            "screen_draft_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_diagnosis_draft_id_nt_diagnoses_drafts_diagnosis_draft_id_fk": {
+          "name": "nt_pending_deletion_diagnosis_draft_id_nt_diagnoses_drafts_diagnosis_draft_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_diagnoses_drafts",
+          "columnsFrom": [
+            "diagnosis_draft_id"
+          ],
+          "columnsTo": [
+            "diagnosis_draft_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_config_key_draft_id_nt_config_keys_drafts_config_key_draft_id_fk": {
+          "name": "nt_pending_deletion_config_key_draft_id_nt_config_keys_drafts_config_key_draft_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_config_keys_drafts",
+          "columnsFrom": [
+            "config_key_draft_id"
+          ],
+          "columnsTo": [
+            "config_key_draft_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_hospital_draft_id_nt_hospitals_drafts_hospital_draft_id_fk": {
+          "name": "nt_pending_deletion_hospital_draft_id_nt_hospitals_drafts_hospital_draft_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_hospitals_drafts",
+          "columnsFrom": [
+            "hospital_draft_id"
+          ],
+          "columnsTo": [
+            "hospital_draft_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_drugs_library_item_draft_id_nt_drugs_library_drafts_item_draft_id_fk": {
+          "name": "nt_pending_deletion_drugs_library_item_draft_id_nt_drugs_library_drafts_item_draft_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_drugs_library_drafts",
+          "columnsFrom": [
+            "drugs_library_item_draft_id"
+          ],
+          "columnsTo": [
+            "item_draft_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_data_key_id_nt_data_keys_uuid_fk": {
+          "name": "nt_pending_deletion_data_key_id_nt_data_keys_uuid_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_data_keys",
+          "columnsFrom": [
+            "data_key_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_data_key_draft_id_nt_data_keys_uuid_fk": {
+          "name": "nt_pending_deletion_data_key_draft_id_nt_data_keys_uuid_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_data_keys",
+          "columnsFrom": [
+            "data_key_draft_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_alias_id_nt_aliases_uuid_fk": {
+          "name": "nt_pending_deletion_alias_id_nt_aliases_uuid_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_created_by_user_id_nt_users_user_id_fk": {
+          "name": "nt_pending_deletion_created_by_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nt_screens": {
+      "name": "nt_screens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "screen_id": {
+          "name": "screen_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "old_screen_id": {
+          "name": "old_screen_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_script_id": {
+          "name": "old_script_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "screen_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'editor'"
+        },
+        "section_title": {
+          "name": "section_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_title": {
+          "name": "preview_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "preview_print_title": {
+          "name": "preview_print_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "skip_to_condition": {
+          "name": "skip_to_condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "skip_to_screen_id": {
+          "name": "skip_to_screen_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "epic_id": {
+          "name": "epic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ref_id_data_key": {
+          "name": "ref_id_data_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ref_key": {
+          "name": "ref_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ref_key_data_key": {
+          "name": "ref_key_data_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "step": {
+          "name": "step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "action_text": {
+          "name": "action_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "content_text": {
+          "name": "content_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "content_text_image": {
+          "name": "content_text_image",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "info_text": {
+          "name": "info_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title1": {
+          "name": "title1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "title2": {
+          "name": "title2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "title3": {
+          "name": "title3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "title4": {
+          "name": "title4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "text1": {
+          "name": "text1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "text2": {
+          "name": "text2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "text3": {
+          "name": "text3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "image1": {
+          "name": "image1",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image2": {
+          "name": "image2",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image3": {
+          "name": "image3",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "instructions2": {
+          "name": "instructions2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "instructions3": {
+          "name": "instructions3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "instructions4": {
+          "name": "instructions4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "hcw_diagnoses_instructions": {
+          "name": "hcw_diagnoses_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "suggested_diagnoses_instructions": {
+          "name": "suggested_diagnoses_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "negative_label": {
+          "name": "negative_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "positive_label": {
+          "name": "positive_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "timer_value": {
+          "name": "timer_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multiplier": {
+          "name": "multiplier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_value": {
+          "name": "min_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_value": {
+          "name": "max_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exportable": {
+          "name": "exportable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "printable": {
+          "name": "printable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skippable": {
+          "name": "skippable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "confidential": {
+          "name": "confidential",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pre_populate": {
+          "name": "pre_populate",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "items": {
+          "name": "items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"fontSize\":{},\"fontWeight\":{},\"fontStyle\":{},\"textColor\":{},\"backgroundColor\":{},\"highlight\":{}}'"
+        },
+        "drugs": {
+          "name": "drugs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "fluids": {
+          "name": "fluids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "feeds": {
+          "name": "feeds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "list_style": {
+          "name": "list_style",
+          "type": "list_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "print_display_columns": {
+          "name": "print_display_columns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_name": {
+          "name": "collection_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "collection_label": {
+          "name": "collection_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "repeatable": {
+          "name": "repeatable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "screens_search_index": {
+          "name": "screens_search_index",
+          "columns": [
+            {
+              "expression": "(\n                    to_tsvector('english', \"title\")\n                )",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nt_screens_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_screens_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_screens",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_screens_screen_id_unique": {
+          "name": "nt_screens_screen_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "screen_id"
+          ]
+        },
+        "nt_screens_old_screen_id_unique": {
+          "name": "nt_screens_old_screen_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "old_screen_id"
+          ]
+        }
+      }
+    },
+    "public.nt_screens_drafts": {
+      "name": "nt_screens_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "screen_draft_id": {
+          "name": "screen_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "screen_id": {
+          "name": "screen_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "script_draft_id": {
+          "name": "script_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "screen_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_screens_drafts_screen_id_nt_screens_screen_id_fk": {
+          "name": "nt_screens_drafts_screen_id_nt_screens_screen_id_fk",
+          "tableFrom": "nt_screens_drafts",
+          "tableTo": "nt_screens",
+          "columnsFrom": [
+            "screen_id"
+          ],
+          "columnsTo": [
+            "screen_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_screens_drafts_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_screens_drafts_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_screens_drafts",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_screens_drafts_script_draft_id_nt_scripts_drafts_script_draft_id_fk": {
+          "name": "nt_screens_drafts_script_draft_id_nt_scripts_drafts_script_draft_id_fk",
+          "tableFrom": "nt_screens_drafts",
+          "tableTo": "nt_scripts_drafts",
+          "columnsFrom": [
+            "script_draft_id"
+          ],
+          "columnsTo": [
+            "script_draft_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_screens_drafts_created_by_user_id_nt_users_user_id_fk": {
+          "name": "nt_screens_drafts_created_by_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_screens_drafts",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_screens_drafts_screen_draft_id_unique": {
+          "name": "nt_screens_drafts_screen_draft_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "screen_draft_id"
+          ]
+        }
+      }
+    },
+    "public.nt_screens_history": {
+      "name": "nt_screens_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "screen_id": {
+          "name": "screen_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restore_key": {
+          "name": "restore_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_screens_history_screen_id_nt_screens_screen_id_fk": {
+          "name": "nt_screens_history_screen_id_nt_screens_screen_id_fk",
+          "tableFrom": "nt_screens_history",
+          "tableTo": "nt_screens",
+          "columnsFrom": [
+            "screen_id"
+          ],
+          "columnsTo": [
+            "screen_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_screens_history_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_screens_history_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_screens_history",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nt_scripts": {
+      "name": "nt_scripts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "old_script_id": {
+          "name": "old_script_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "script_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admission'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'editor'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "print_title": {
+          "name": "print_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "hospital_id": {
+          "name": "hospital_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exportable": {
+          "name": "exportable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "nuid_search_enabled": {
+          "name": "nuid_search_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nuid_search_fields": {
+          "name": "nuid_search_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "reviewable": {
+          "name": "reviewable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_configurations": {
+          "name": "review_configurations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"fontSize\":{},\"fontWeight\":{},\"fontStyle\":{},\"textColor\":{},\"backgroundColor\":{},\"highlight\":{}}'"
+        },
+        "print_config": {
+          "name": "print_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\n              \"headerFormat\": \"\",\n              \"headerFields\": [],\n              \"footerFields\": [],\n              \"sections\": []\n            }'"
+        },
+        "print_sections": {
+          "name": "print_sections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "scripts_search_index": {
+          "name": "scripts_search_index",
+          "columns": [
+            {
+              "expression": "(\n                    to_tsvector('english', \"title\") ||\n                    to_tsvector('english', \"description\")\n                )",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nt_scripts_hospital_id_nt_hospitals_hospital_id_fk": {
+          "name": "nt_scripts_hospital_id_nt_hospitals_hospital_id_fk",
+          "tableFrom": "nt_scripts",
+          "tableTo": "nt_hospitals",
+          "columnsFrom": [
+            "hospital_id"
+          ],
+          "columnsTo": [
+            "hospital_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_scripts_script_id_unique": {
+          "name": "nt_scripts_script_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "script_id"
+          ]
+        },
+        "nt_scripts_old_script_id_unique": {
+          "name": "nt_scripts_old_script_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "old_script_id"
+          ]
+        }
+      }
+    },
+    "public.nt_scripts_drafts": {
+      "name": "nt_scripts_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "script_draft_id": {
+          "name": "script_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hospital_id": {
+          "name": "hospital_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_scripts_drafts_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_scripts_drafts_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_scripts_drafts",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_scripts_drafts_hospital_id_nt_hospitals_hospital_id_fk": {
+          "name": "nt_scripts_drafts_hospital_id_nt_hospitals_hospital_id_fk",
+          "tableFrom": "nt_scripts_drafts",
+          "tableTo": "nt_hospitals",
+          "columnsFrom": [
+            "hospital_id"
+          ],
+          "columnsTo": [
+            "hospital_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "nt_scripts_drafts_created_by_user_id_nt_users_user_id_fk": {
+          "name": "nt_scripts_drafts_created_by_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_scripts_drafts",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_scripts_drafts_script_draft_id_unique": {
+          "name": "nt_scripts_drafts_script_draft_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "script_draft_id"
+          ]
+        }
+      }
+    },
+    "public.nt_scripts_history": {
+      "name": "nt_scripts_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restore_key": {
+          "name": "restore_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_scripts_history_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_scripts_history_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_scripts_history",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nt_sites": {
+      "name": "nt_sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "site_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "site_env",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'production'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_iso": {
+          "name": "country_iso",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_name": {
+          "name": "country_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_sites_site_id_unique": {
+          "name": "nt_sites_site_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "site_id"
+          ]
+        },
+        "nt_sites_name_unique": {
+          "name": "nt_sites_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "nt_sites_link_unique": {
+          "name": "nt_sites_link_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "link"
+          ]
+        }
+      }
+    },
+    "public.nt_sys": {
+      "name": "nt_sys",
+      "schema": "",
+      "columns": {
+        "_id": {
+          "name": "_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_sys_id_unique": {
+          "name": "nt_sys_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "nt_sys_key_unique": {
+          "name": "nt_sys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      }
+    },
+    "public.nt_tokens": {
+      "name": "nt_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_tokens_user_id_nt_users_user_id_fk": {
+          "name": "nt_tokens_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_tokens",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_tokens_token_unique": {
+          "name": "nt_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      }
+    },
+    "public.nt_user_roles": {
+      "name": "nt_user_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "role_name",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_user_roles_name_unique": {
+          "name": "nt_user_roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.nt_users": {
+      "name": "nt_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role": {
+          "name": "role",
+          "type": "role_name",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_sm": {
+          "name": "avatar_sm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_md": {
+          "name": "avatar_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activation_date": {
+          "name": "activation_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_date": {
+          "name": "last_login_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_search_index": {
+          "name": "users_search_index",
+          "columns": [
+            {
+              "expression": "(\n                    to_tsvector('english', \"email\") ||\n                    to_tsvector('english', \"display_name\") ||\n                    to_tsvector('english', \"first_name\") ||\n                    to_tsvector('english', \"last_name\")\n                )",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nt_users_role_nt_user_roles_name_fk": {
+          "name": "nt_users_role_nt_user_roles_name_fk",
+          "tableFrom": "nt_users",
+          "tableTo": "nt_user_roles",
+          "columnsFrom": [
+            "role"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_users_user_id_unique": {
+          "name": "nt_users_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "nt_users_email_unique": {
+          "name": "nt_users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    },
+    "public.nt_data_keys": {
+      "name": "nt_data_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "md5(random()::text || clock_timestamp()::text)::uuid"
+        },
+        "unique_key": {
+          "name": "unique_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "md5(random()::text || clock_timestamp()::text)::uuid"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_data_keys_uuid_unique": {
+          "name": "nt_data_keys_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        },
+        "nt_data_keys_unique_key_unique": {
+          "name": "nt_data_keys_unique_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "unique_key"
+          ]
+        }
+      }
+    },
+    "public.nt_data_keys_drafts": {
+      "name": "nt_data_keys_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "md5(random()::text || clock_timestamp()::text)::uuid"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unique_key": {
+          "name": "unique_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_key_id": {
+          "name": "data_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_data_keys_drafts_data_key_id_nt_data_keys_uuid_fk": {
+          "name": "nt_data_keys_drafts_data_key_id_nt_data_keys_uuid_fk",
+          "tableFrom": "nt_data_keys_drafts",
+          "tableTo": "nt_data_keys",
+          "columnsFrom": [
+            "data_key_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_data_keys_drafts_uuid_unique": {
+          "name": "nt_data_keys_drafts_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      }
+    },
+    "public.nt_data_keys_history": {
+      "name": "nt_data_keys_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_key_id": {
+          "name": "data_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restore_key": {
+          "name": "restore_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_data_keys_history_data_key_id_nt_data_keys_uuid_fk": {
+          "name": "nt_data_keys_history_data_key_id_nt_data_keys_uuid_fk",
+          "tableFrom": "nt_data_keys_history",
+          "tableTo": "nt_data_keys",
+          "columnsFrom": [
+            "data_key_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nt_aliases": {
+      "name": "nt_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "md5(random()::text || clock_timestamp()::text)::uuid"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_script": {
+          "name": "old_script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_aliases_uuid_unique": {
+          "name": "nt_aliases_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.change_log_action": {
+      "name": "change_log_action",
+      "schema": "public",
+      "values": [
+        "create",
+        "update",
+        "delete",
+        "publish",
+        "restore",
+        "rollback",
+        "merge"
+      ]
+    },
+    "public.change_log_entity": {
+      "name": "change_log_entity",
+      "schema": "public",
+      "values": [
+        "script",
+        "screen",
+        "diagnosis",
+        "config_key",
+        "drugs_library",
+        "data_key",
+        "alias",
+        "hospital",
+        "release"
+      ]
+    },
+    "public.drug_type": {
+      "name": "drug_type",
+      "schema": "public",
+      "values": [
+        "drug",
+        "fluid",
+        "feed"
+      ]
+    },
+    "public.dff_item_validation_type": {
+      "name": "dff_item_validation_type",
+      "schema": "public",
+      "values": [
+        "default",
+        "condition"
+      ]
+    },
+    "public.list_style": {
+      "name": "list_style",
+      "schema": "public",
+      "values": [
+        "none",
+        "number",
+        "bullet"
+      ]
+    },
+    "public.mailer_service": {
+      "name": "mailer_service",
+      "schema": "public",
+      "values": [
+        "gmail",
+        "smtp"
+      ]
+    },
+    "public.role_name": {
+      "name": "role_name",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "super_user"
+      ]
+    },
+    "public.screen_type": {
+      "name": "screen_type",
+      "schema": "public",
+      "values": [
+        "diagnosis",
+        "checklist",
+        "form",
+        "management",
+        "multi_select",
+        "single_select",
+        "progress",
+        "timer",
+        "yesno",
+        "drugs",
+        "fluids",
+        "feeds",
+        "zw_edliz_summary_table",
+        "mwi_edliz_summary_table",
+        "edliz_summary_table",
+        "dynamic_form"
+      ]
+    },
+    "public.script_type": {
+      "name": "script_type",
+      "schema": "public",
+      "values": [
+        "admission",
+        "discharge",
+        "neolab",
+        "drecord",
+        "dff_calculator"
+      ]
+    },
+    "public.site_env": {
+      "name": "site_env",
+      "schema": "public",
+      "values": [
+        "production",
+        "stage",
+        "development",
+        "demo"
+      ]
+    },
+    "public.site_type": {
+      "name": "site_type",
+      "schema": "public",
+      "values": [
+        "nodeapi",
+        "webeditor"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/databases/pg/migrations/meta/_journal.json
+++ b/databases/pg/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1768655509983,
       "tag": "0006_familiar_karma",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1768813029939,
+      "tag": "0007_fantastic_shadow_king",
+      "breakpoints": true
     }
   ]
 }

--- a/databases/queries/changelogs/_get-data-version-summaries.ts
+++ b/databases/queries/changelogs/_get-data-version-summaries.ts
@@ -1,0 +1,280 @@
+import { and, desc, eq, sql, inArray, or, ilike, asc } from "drizzle-orm"
+import db from "@/databases/pg/drizzle"
+import { changeLogs, users } from "@/databases/pg/schema"
+import logger from "@/lib/logger"
+
+export type DataVersionSummaryParams = {
+  searchTerm?: string
+  entityTypes?: (typeof changeLogs.$inferSelect)["entityType"][]
+  actions?: (typeof changeLogs.$inferSelect)["action"][]
+  limit?: number
+  offset?: number
+  applyFiltersToCounts?: boolean
+  dataVersions?: number[]
+  sortBy?: "publishedAt" | "dataVersion" | "changeCount"
+  sortOrder?: "asc" | "desc"
+  latestOnly?: boolean
+}
+
+export type DataVersionSummary = {
+  dataVersion: number
+  publishedAt: string | null
+  publishedByName: string
+  publishedByEmail?: string
+  totalChanges: number
+  hasActiveChanges: boolean
+  isLatestVersion: boolean
+  entityCounts: Record<string, number>
+  actionCounts: Record<string, number>
+  descriptions: string[]
+  rollbackSourceVersion?: number | null
+}
+
+export type DataVersionSummaryResults = {
+  data: DataVersionSummary[]
+  total: number
+  latestDataVersion?: number | null
+  errors?: string[]
+}
+
+export async function _getDataVersionSummaries(params?: DataVersionSummaryParams): Promise<DataVersionSummaryResults> {
+  try {
+    const {
+      searchTerm,
+      entityTypes = [],
+      actions = [],
+      limit = 25,
+      offset = 0,
+      applyFiltersToCounts = false,
+      dataVersions = [],
+      sortBy = "publishedAt",
+      sortOrder = "desc",
+      latestOnly = false,
+    } = {
+      ...params,
+    }
+
+    const numericDataVersions = dataVersions.filter((value) => Number.isFinite(value)).map((value) => Number(value))
+
+    const latestDataVersionRes = await db
+      .select({ latestDataVersion: sql<number>`max(${changeLogs.dataVersion})` })
+      .from(changeLogs)
+      .where(sql`${changeLogs.dataVersion} IS NOT NULL`)
+    const latestDataVersion = Number.isFinite(latestDataVersionRes?.[0]?.latestDataVersion)
+      ? Number(latestDataVersionRes?.[0]?.latestDataVersion)
+      : null
+
+    if (latestOnly && !latestDataVersion) {
+      return { data: [], total: 0, latestDataVersion: null }
+    }
+
+    const versionFilter =
+      latestOnly && latestDataVersion
+        ? [latestDataVersion]
+        : numericDataVersions.length
+          ? numericDataVersions
+          : []
+
+    // First, let's find the data versions that match our filters
+    const searchConditions = searchTerm
+      ? or(
+          ilike(changeLogs.description, `%${searchTerm}%`),
+          ilike(changeLogs.changeReason, `%${searchTerm}%`),
+          sql`${changeLogs.changes}::text ILIKE ${"%" + searchTerm + "%"}`,
+          ilike(users.displayName, `%${searchTerm}%`),
+          ilike(users.email, `%${searchTerm}%`),
+        )
+      : undefined
+
+    const publishDateExpr = sql<Date>`max(case when ${changeLogs.action} = 'publish' then ${changeLogs.dateOfChange} end)`
+    const latestChangeExpr = sql<Date>`max(${changeLogs.dateOfChange})`
+    const effectivePublishDateExpr = sql<Date>`coalesce(${publishDateExpr}, ${latestChangeExpr})`
+    const changeCountExpr = sql<number>`count(*)::int`
+
+    const orderByClause = (() => {
+      if (sortBy === "dataVersion") {
+        return sortOrder === "asc" ? asc(changeLogs.dataVersion) : desc(changeLogs.dataVersion)
+      }
+      if (sortBy === "changeCount") {
+        return sortOrder === "asc" ? asc(changeCountExpr) : desc(changeCountExpr)
+      }
+      return sortOrder === "asc" ? asc(effectivePublishDateExpr) : desc(effectivePublishDateExpr)
+    })()
+
+    const matchingVersionsQuery = db
+      .select({
+        dataVersion: changeLogs.dataVersion,
+        latestPublishedAt: publishDateExpr,
+        latestChangeAt: latestChangeExpr,
+        changeCount: changeCountExpr,
+      })
+      .from(changeLogs)
+      .leftJoin(users, eq(users.userId, changeLogs.userId))
+      .where(
+        and(
+          searchConditions,
+          entityTypes.length ? inArray(changeLogs.entityType, entityTypes) : undefined,
+          actions.length ? inArray(changeLogs.action, actions) : undefined,
+          versionFilter.length ? inArray(changeLogs.dataVersion, versionFilter) : undefined,
+          sql`${changeLogs.dataVersion} IS NOT NULL`,
+        ),
+      )
+      .groupBy(changeLogs.dataVersion)
+      .orderBy(orderByClause)
+
+    const totalQuery = db
+      .select({
+        total: sql<number>`count(distinct ${changeLogs.dataVersion})`,
+      })
+      .from(changeLogs)
+      .leftJoin(users, eq(users.userId, changeLogs.userId))
+      .where(
+        and(
+          searchConditions,
+          entityTypes.length ? inArray(changeLogs.entityType, entityTypes) : undefined,
+          actions.length ? inArray(changeLogs.action, actions) : undefined,
+          versionFilter.length ? inArray(changeLogs.dataVersion, versionFilter) : undefined,
+          sql`${changeLogs.dataVersion} IS NOT NULL`,
+        ),
+      )
+
+    const [matchingVersions, totalRes] = await Promise.all([matchingVersionsQuery.limit(limit).offset(offset), totalQuery])
+    const total = Number(totalRes?.[0]?.total ?? 0)
+    const paginatedVersions = matchingVersions.map((v) => v.dataVersion as number)
+
+    if (paginatedVersions.length === 0) {
+      return { data: [], total, latestDataVersion }
+    }
+
+    // Now fetch all changelogs for these specific data versions to build summaries
+    const logs = await db
+      .select({
+        changeLog: changeLogs,
+        user: {
+          name: users.displayName,
+          email: users.email,
+        },
+      })
+      .from(changeLogs)
+      .leftJoin(users, eq(users.userId, changeLogs.userId))
+      .where(
+        and(
+          inArray(changeLogs.dataVersion, paginatedVersions),
+          applyFiltersToCounts ? searchConditions : undefined,
+          applyFiltersToCounts && entityTypes.length ? inArray(changeLogs.entityType, entityTypes) : undefined,
+          applyFiltersToCounts && actions.length ? inArray(changeLogs.action, actions) : undefined,
+          applyFiltersToCounts && versionFilter.length ? inArray(changeLogs.dataVersion, versionFilter) : undefined,
+        ),
+      )
+      .orderBy(desc(changeLogs.dateOfChange))
+
+    const grouped = new Map<number, any[]>()
+    for (const log of logs) {
+      const dv = log.changeLog.dataVersion as number
+      if (!grouped.has(dv)) grouped.set(dv, [])
+      grouped.get(dv)!.push(log)
+    }
+
+    const entitiesForActiveCheck = new Map<string, { entityType: string; entityId: string }>()
+    for (const log of logs) {
+      const entityType = log.changeLog.entityType
+      const entityId = log.changeLog.entityId
+      if (!entityType || !entityId) continue
+      const key = `${entityType}:${entityId}`
+      if (!entitiesForActiveCheck.has(key)) {
+        entitiesForActiveCheck.set(key, { entityType, entityId })
+      }
+    }
+
+    const entityPairs = Array.from(entitiesForActiveCheck.values())
+    const latestVersions = entityPairs.length
+      ? await db
+          .select({
+            entityType: changeLogs.entityType,
+            entityId: changeLogs.entityId,
+            latestVersion: sql<number>`max(${changeLogs.version})`,
+          })
+          .from(changeLogs)
+          .where(
+            or(
+              ...entityPairs.map((e) =>
+                and(
+                  eq(changeLogs.entityType, e.entityType as typeof changeLogs.$inferSelect.entityType),
+                  eq(changeLogs.entityId, e.entityId)
+                )
+              )
+            )
+          )
+          .groupBy(changeLogs.entityType, changeLogs.entityId)
+      : []
+
+    const latestVersionMap = new Map<string, number>()
+    for (const row of latestVersions) {
+      if (row.latestVersion === null || row.latestVersion === undefined) continue
+      latestVersionMap.set(`${row.entityType}:${row.entityId}`, Number(row.latestVersion))
+    }
+
+    const summaries: DataVersionSummary[] = paginatedVersions.map((dv) => {
+      const versionLogs = grouped.get(dv) || []
+      const latestChange = versionLogs[0]
+      
+      const publishEntry =
+        versionLogs.find((l) => l.changeLog.action === "publish" && l.changeLog.entityType === "release") ||
+        versionLogs.find((l) => l.changeLog.action === "publish") ||
+        latestChange
+
+      const rollbackEntry = versionLogs.find((l) => l.changeLog.action === "rollback")
+      
+      const entityCounts: Record<string, number> = {}
+      const actionCounts: Record<string, number> = {}
+      const descriptionsSet = new Set<string>()
+
+      versionLogs.forEach((l) => {
+        const type = l.changeLog.entityType
+        const act = l.changeLog.action
+        entityCounts[type] = (entityCounts[type] || 0) + 1
+        actionCounts[act] = (actionCounts[act] || 0) + 1
+        if (l.changeLog.description) descriptionsSet.add(l.changeLog.description)
+      })
+
+      const hasActiveChanges = versionLogs.some((l) => {
+        const key = `${l.changeLog.entityType}:${l.changeLog.entityId}`
+        const latest = latestVersionMap.get(key)
+        return latest !== undefined ? l.changeLog.version === latest : l.changeLog.isActive
+      })
+
+      const rollbackChanges = Array.isArray(rollbackEntry?.changeLog?.changes) ? rollbackEntry?.changeLog?.changes : []
+      const rollbackToVersion =
+        rollbackChanges.find((c: any) => Number.isFinite(c?.toVersion))?.toVersion ??
+        rollbackChanges.find((c: any) => Number.isFinite(c?.to_version))?.to_version ??
+        rollbackEntry?.changeLog?.changes?.[0]?.toVersion ??
+        null
+
+      return {
+        dataVersion: dv,
+        publishedAt:
+          publishEntry?.changeLog?.dateOfChange?.toISOString() ||
+          latestChange?.changeLog?.dateOfChange?.toISOString() ||
+          null,
+        publishedByName: publishEntry?.user?.name || "Unknown user",
+        publishedByEmail: publishEntry?.user?.email || undefined,
+        totalChanges: versionLogs.length,
+        hasActiveChanges,
+        isLatestVersion: latestDataVersion ? dv === latestDataVersion : false,
+        entityCounts,
+        actionCounts,
+        descriptions: Array.from(descriptionsSet).slice(0, 5),
+        rollbackSourceVersion: rollbackEntry ? rollbackToVersion : null,
+      }
+    })
+
+    return {
+      data: summaries,
+      total,
+      latestDataVersion,
+    }
+  } catch (e: any) {
+    logger.error("_getDataVersionSummaries ERROR", e.message)
+    return { data: [], total: 0, latestDataVersion: null, errors: [e.message] }
+  }
+}

--- a/databases/queries/changelogs/index.ts
+++ b/databases/queries/changelogs/index.ts
@@ -1,4 +1,5 @@
 export * from './_get-change-logs-metadata';
 export * from './_get-change-logs';
 export * from './_count-change-logs';
+export * from './_get-data-version-summaries';
 export * as SearchChangeLogs from './_search-change-logs';


### PR DESCRIPTION
Summary

Move changelog summaries to server-side filtering/sorting/pagination and add richer search (entityId, entityType, user).
Improve summaries data integrity (publish timestamp, latest version metadata, active reconciliation) and rollback metadata.
Enhance rollback UX with loader + option to soft-delete newly created entities during rollback.
Key Changes

Backend: _getDataVersionSummaries now supports sorting, pagination, latest-only, entity/user search, and friendly entity type aliases.
UI: changelog table uses /api/changelogs/summaries and lazy-loads details for rollback modal.
Rollback: new createdEntityPolicy option (keep vs soft_delete), plus UI toggle.
Fix: ensure hospital rollbacks include hospitalId.