### PR TITLE
Relax userId UUID validation in changelog flows

### DIFF
--- a/databases/mutations/changelogs/_rollback-data-version.ts
+++ b/databases/mutations/changelogs/_rollback-data-version.ts
@@ -18,6 +18,12 @@ import {
 } from "@/databases/pg/schema"
 import { _saveChangeLog, type SaveChangeLogData } from "./_save-change-log"
 
+const UUID_LOOSE_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function isUuidLike(value: unknown): value is string {
+  return typeof value === "string" && UUID_LOOSE_REGEX.test(value)
+}
+
 export type RollbackDataVersionParams = {
   dataVersion?: number
   userId: string
@@ -310,7 +316,7 @@ export async function _rollbackDataVersion({
   let restoredVersion: number | undefined
 
   try {
-    if (!uuid.validate(userId)) throw new Error("Invalid userId")
+    if (!isUuidLike(userId)) throw new Error("Invalid userId")
 
     await db.transaction(async (tx) => {
       const lockedEditorInfo = await tx.execute<{ id: number; dataVersion: number }>(

--- a/databases/mutations/changelogs/_rollback-data-version.ts
+++ b/databases/mutations/changelogs/_rollback-data-version.ts
@@ -1,8 +1,8 @@
 import { and, desc, eq, lt, sql } from "drizzle-orm"
 import { createHash } from "crypto"
-import * as uuid from "uuid"
 
 import logger from "@/lib/logger"
+import { isUuidLike } from "@/lib/uuid"
 import db from "@/databases/pg/drizzle"
 import {
   aliases,
@@ -17,12 +17,6 @@ import {
   scripts,
 } from "@/databases/pg/schema"
 import { _saveChangeLog, type SaveChangeLogData } from "./_save-change-log"
-
-const UUID_LOOSE_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-
-function isUuidLike(value: unknown): value is string {
-  return typeof value === "string" && UUID_LOOSE_REGEX.test(value)
-}
 
 export type RollbackDataVersionParams = {
   dataVersion?: number

--- a/databases/mutations/changelogs/_save-change-log.ts
+++ b/databases/mutations/changelogs/_save-change-log.ts
@@ -3,6 +3,7 @@ import { createHash } from "crypto"
 import * as uuid from "uuid"
 
 import logger from "@/lib/logger"
+import { isUuidLike } from "@/lib/uuid"
 import db from "@/databases/pg/drizzle"
 import { getAuthenticatedUser } from "@/app/actions/get-authenticated-user"
 import {
@@ -141,12 +142,6 @@ const ENTITY_FETCH_CONFIG: Partial<Record<EntityType, EntityFetchConfig>> = {
 type DbClient = typeof db
 type TransactionClient = Parameters<Parameters<typeof db.transaction>[0]>[0]
 type DbOrTransaction = DbClient | TransactionClient
-
-const UUID_LOOSE_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-
-function isUuidLike(value: unknown): value is string {
-  return typeof value === "string" && UUID_LOOSE_REGEX.test(value)
-}
 
 function hashToInt32(value: string): number {
   let hash = 0

--- a/databases/queries/changelogs/_count-change-logs.ts
+++ b/databases/queries/changelogs/_count-change-logs.ts
@@ -4,6 +4,7 @@ import * as uuid from "uuid";
 import db from "@/databases/pg/drizzle";
 import { changeLogs } from "@/databases/pg/schema";
 import logger from "@/lib/logger";
+import { isUuidLike } from "@/lib/uuid";
 
 export type CountChangeLogsParams = {
     entityIds?: string[];
@@ -42,7 +43,7 @@ export async function _countChangeLogs(
 
         // Filter valid UUIDs
         entityIds = entityIds.filter(id => uuid.validate(id));
-        userIds = userIds.filter(id => uuid.validate(id));
+        userIds = userIds.filter(id => isUuidLike(id));
         scriptIds = scriptIds.filter(id => uuid.validate(id));
         screenIds = screenIds.filter(id => uuid.validate(id));
         diagnosisIds = diagnosisIds.filter(id => uuid.validate(id));
@@ -153,7 +154,7 @@ export async function _countChangeLogsByAction(
             .where(and(
                 entityId && uuid.validate(entityId) ? eq(changeLogs.entityId, entityId) : undefined,
                 entityType ? eq(changeLogs.entityType, entityType) : undefined,
-                userId && uuid.validate(userId) ? eq(changeLogs.userId, userId) : undefined,
+                userId && isUuidLike(userId) ? eq(changeLogs.userId, userId) : undefined,
                 startDate ? sql`${changeLogs.dateOfChange} >= ${startDate}` : undefined,
                 endDate ? sql`${changeLogs.dateOfChange} <= ${endDate}` : undefined,
             ))

--- a/databases/queries/changelogs/_get-change-logs-metadata.ts
+++ b/databases/queries/changelogs/_get-change-logs-metadata.ts
@@ -4,6 +4,7 @@ import * as uuid from "uuid";
 import db from "@/databases/pg/drizzle";
 import { changeLogs, users } from "@/databases/pg/schema";
 import logger from "@/lib/logger";
+import { isUuidLike } from "@/lib/uuid";
 import { sanitizeChangeLogForResponse } from "./_get-change-logs";
 
 export type SearchChangeLogsParams = {
@@ -45,7 +46,7 @@ export async function _searchChangeLogs(
         } = { ...params };
 
         // Filter valid UUIDs
-        userIds = userIds.filter(id => uuid.validate(id));
+        userIds = userIds.filter(id => isUuidLike(id));
 
         const searchConditions = searchTerm
             ? or(
@@ -240,7 +241,7 @@ export async function _searchChangeLogsByUser(
 
         const userCondition = userName
             ? ilike(users.displayName, `%${userName}%`)
-            : userId && uuid.validate(userId)
+            : userId && isUuidLike(userId)
                 ? eq(changeLogs.userId, userId)
                 : undefined;
 

--- a/databases/queries/changelogs/_get-change-logs.ts
+++ b/databases/queries/changelogs/_get-change-logs.ts
@@ -4,6 +4,7 @@ import * as uuid from "uuid";
 import db from "@/databases/pg/drizzle";
 import { changeLogs, users, scripts, screens, diagnoses, configKeys, drugsLibrary, dataKeys, aliases } from "@/databases/pg/schema";
 import logger from "@/lib/logger";
+import { isUuidLike } from "@/lib/uuid";
 
 export type GetChangeLogsParams = {
     changeLogIds?: string[];
@@ -118,7 +119,7 @@ export async function _getChangeLogs(
         // Filter valid UUIDs
         changeLogIds = changeLogIds.filter(id => uuid.validate(id));
         entityIds = entityIds.filter(id => uuid.validate(id));
-        userIds = userIds.filter(id => uuid.validate(id));
+        userIds = userIds.filter(id => isUuidLike(id));
         scriptIds = scriptIds.filter(id => uuid.validate(id));
         screenIds = screenIds.filter(id => uuid.validate(id));
         diagnosisIds = diagnosisIds.filter(id => uuid.validate(id));

--- a/databases/queries/changelogs/_search-change-logs.ts
+++ b/databases/queries/changelogs/_search-change-logs.ts
@@ -4,6 +4,7 @@ import * as uuid from "uuid";
 import db from "@/databases/pg/drizzle";
 import { changeLogs, users } from "@/databases/pg/schema";
 import logger from "@/lib/logger";
+import { isUuidLike } from "@/lib/uuid";
 
 export type SearchChangeLogsParams = {
     searchTerm?: string;
@@ -44,7 +45,7 @@ export async function _searchChangeLogs(
         } = { ...params };
 
         // Filter valid UUIDs
-        userIds = userIds.filter(id => uuid.validate(id));
+        userIds = userIds.filter(id => isUuidLike(id));
 
         const searchConditions = searchTerm
             ? or(
@@ -226,7 +227,7 @@ export async function _searchChangeLogsByUser(
 
         const userCondition = userName
             ? ilike(users.displayName, `%${userName}%`)
-            : userId && uuid.validate(userId)
+            : userId && isUuidLike(userId)
                 ? eq(changeLogs.userId, userId)
                 : undefined;
 

--- a/lib/uuid.ts
+++ b/lib/uuid.ts
@@ -1,0 +1,5 @@
+const UUID_LOOSE_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function isUuidLike(value: unknown): value is string {
+  return typeof value === "string" && UUID_LOOSE_REGEX.test(value)
+}


### PR DESCRIPTION
We were rejecting valid Postgres UUIDs (non‑RFC4122 variants) as “Invalid userId”, causing changelog writes/queries to fail even when the user existed in nt_users. This change centralizes a “UUID‑shaped” validator and uses it for userId handling in changelog mutations and queries.

Changes

Add uuid.ts with isUuidLike (loose UUID regex).
Use isUuidLike for userId validation in changelog save and rollback.
Use isUuidLike for changelog query filters and search-by-user conditions.
Keep entityId/changeLogId validation strict (uuid.validate) to avoid broadening scope.

Why
Postgres accepts UUIDs that fail RFC4122 version checks (e.g. IDs with version nibble a). The app was treating those as invalid userIds even though they were legitimate rows in nt_users.