### PR TITLE
Improve manual-entry authoring + discoverability across editor, and tighten exact-search behavior

### DIFF
--- a/app/(dashboard)/(scripts)/components/screens/field-items.tsx
+++ b/app/(dashboard)/(scripts)/components/screens/field-items.tsx
@@ -79,6 +79,7 @@ export function FieldItems({
             item.label,
             item.exclusive ? "✓" : "✕",
             item.enterValueManually ? "✓" : "✕",
+            item.enterValueManuallyLabel || "",
             item.exclusiveGroup || "",
             item.forbidWith?.length ? `${item.forbidWith.length}` : "",
             "",
@@ -109,6 +110,9 @@ export function FieldItems({
             {
               name: "Enter Value Manually",
               align: "center",
+            },
+            {
+              name: "Manual Value Label",
             },
             {
               name: "Exclusive Group",
@@ -182,10 +186,11 @@ function Form({
 }) {
   const { extractDataKeys } = useDataKeysCtx()
 
-  const { control, register, handleSubmit, setValue } = useForm<Item>({
+  const { control, register, handleSubmit, setValue, watch } = useForm<Item>({
     defaultValues: {
       ...item,
       enterValueManually: item?.enterValueManually || false,
+      enterValueManuallyLabel: item?.enterValueManuallyLabel || "",
       exclusive: item?.exclusive || false,
       exclusiveGroup: item?.exclusiveGroup || "",
       forbidWith: item?.forbidWith || [],
@@ -196,6 +201,7 @@ function Form({
       keyId: item?.keyId,
     },
   })
+  const enterValueManually = watch("enterValueManually")
 
   const forbidOptions = useMemo(() => {
     const currentItemId = item?.itemId
@@ -325,6 +331,22 @@ function Form({
                 )
               }}
             />
+
+            {enterValueManually && (
+              <div className="px-4">
+                <Label htmlFor="enterValueManuallyLabel">Manual value label</Label>
+                <Input
+                  disabled={false}
+                  {...register("enterValueManuallyLabel", {
+                    required: true,
+                    disabled: false,
+                  })}
+                />
+                <span className="text-xs text-muted-foreground">
+                  Shown to users when they need to enter a custom value.
+                </span>
+              </div>
+            )}
           </div>
 
           <div className="border-t border-t-border px-4 py-2 flex gap-x-2 items-center">

--- a/app/(dashboard)/(scripts)/components/screens/item.tsx
+++ b/app/(dashboard)/(scripts)/components/screens/item.tsx
@@ -93,6 +93,7 @@ export function Item<P = {}>({
       confidential: item?.confidential || false,
       checked: item?.checked || false,
       enterValueManually: item?.enterValueManually || false,
+      enterValueManuallyLabel: item?.enterValueManuallyLabel || "",
       severity_order: item?.severity_order || "",
       summary: item?.summary || "",
       key: item?.key || "",
@@ -466,6 +467,19 @@ export function Item<P = {}>({
                             Enter value manually if selected
                           </Label>
                         </div>
+
+                        {enterValueManually && (
+                          <div>
+                            <Label htmlFor="enterValueManuallyLabel">Manual value label</Label>
+                            <Input
+                              {...register("enterValueManuallyLabel", { disabled, required: enterValueManually })}
+                              name="enterValueManuallyLabel"
+                            />
+                            <span className="text-xs text-muted-foreground">
+                              Shown to users when they enter a custom value for this option.
+                            </span>
+                          </div>
+                        )}
                       </>
                     )}
 

--- a/databases/queries/drugs-library/_search.ts
+++ b/databases/queries/drugs-library/_search.ts
@@ -29,7 +29,7 @@ export async function _searchDrugsLibrary({
         const { normalizedValue } = normalizeSearchTerm(rawSearchValue);
         if (!normalizedValue) return { data: [] };
 
-        const pattern = `%${normalizedValue}%`;
+        const pattern = `%${normalizedValue.toLowerCase()}%`;
 
         const drafts = !returnDraftsIfExist ? [] : await db.query.drugsLibraryDrafts.findMany({
             where: sql`lower(${schema.drugsLibraryDrafts.data}::text) like ${pattern}`,

--- a/databases/queries/scripts/_search.ts
+++ b/databases/queries/scripts/_search.ts
@@ -30,7 +30,7 @@ export async function _searchScripts({
 
         if (!normalizedSearchValue) return { data: [], };
 
-        const searchTerm = normalizedSearchValue;
+        const searchTerm = normalizedSearchValue.toLowerCase();
 
         // SCRIPTS
         const scriptsDrafts = !returnDraftsIfExist ? [] : await db.query.scriptsDrafts.findMany({

--- a/databases/types.ts
+++ b/databases/types.ts
@@ -42,6 +42,7 @@ export type ScriptItem = {
     confidential: boolean;
     checked: boolean;
     enterValueManually?: boolean;
+    enterValueManuallyLabel?: string;
     severity_order: string;
     summary: string;
     key: string;
@@ -86,6 +87,7 @@ export type ScriptField = {
         exclusiveGroup?: string;
         forbidWith?: string[];
         enterValueManually?: boolean;
+        enterValueManuallyLabel?: string;
         keyId?: string;
     }[];
 };

--- a/lib/drugs-library-search.ts
+++ b/lib/drugs-library-search.ts
@@ -81,7 +81,7 @@ export function parseDrugsLibrarySearchResults({
     if (!normalizedValue) return [];
 
     const matchesSearch = (value: string) => {
-        const candidate = value.toLowerCase();
+        const candidate = isExactMatch ? value : value.toLowerCase();
         return isExactMatch ? candidate === normalizedValue : candidate.includes(normalizedValue);
     };
 
@@ -239,7 +239,7 @@ export function filterDrugsLibrarySearchResults({
             const matchedFilter = matchedFieldFilterMap[match.field];
             if (matchedFilter !== filter) return false;
 
-            const candidate = `${match.fieldValue}`.toLowerCase();
+            const candidate = isExactMatch ? `${match.fieldValue}` : `${match.fieldValue}`.toLowerCase();
             if (isExactMatch ? candidate !== normalizedValue : !candidate.includes(normalizedValue)) return false;
 
             return true;

--- a/lib/scripts-search.ts
+++ b/lib/scripts-search.ts
@@ -69,21 +69,22 @@ export function parseScriptsSearchResults({
 
     const escapedSearchValue = escapeRegex(normalizedValue);
     const pattern = isExactMatch ? `^${escapedSearchValue}$` : escapedSearchValue;
-    const searchRegex = new RegExp(pattern);
+    const searchRegex = new RegExp(pattern, isExactMatch ? "" : "i");
+    const manualEntrySearchText = 'manual entry enter value manually custom value other specify';
 
     const resultsMap: Record<string, ScriptsSearchResultsItem> = {};
 
     scripts.forEach(s => {
         const matches: ScriptsSearchResultsItem['matches'] = [];
 
-        if (`${s.title || ''}`.toLowerCase().match(searchRegex)) {
+        if (`${s.title || ''}`.match(searchRegex)) {
             matches.push({
                 field: 'title',
                 fieldValue: s.title,
             });
         }
 
-        if (`${s.printTitle || ''}`.toLowerCase().match(searchRegex)) {
+        if (`${s.printTitle || ''}`.match(searchRegex)) {
             matches.push({
                 field: 'printTitle',
                 fieldValue: s.printTitle,
@@ -105,56 +106,56 @@ export function parseScriptsSearchResults({
     screens.forEach(s => {
         const matches: ScriptsSearchResultsItem['matches'] = [];
 
-        if (`${s.title || ''}`.toLowerCase().match(searchRegex)) {
+        if (`${s.title || ''}`.match(searchRegex)) {
             matches.push({
                 field: 'title',
                 fieldValue: s.title,
             });
         }
 
-        if (`${s.key || ''}`.toLowerCase().match(searchRegex)) {
+        if (`${s.key || ''}`.match(searchRegex)) {
             matches.push({
                 field: 'key',
                 fieldValue: s.key!,
             });
         }
 
-        if (`${s.refId || ''}`.toLowerCase().match(searchRegex)) {
+        if (`${s.refId || ''}`.match(searchRegex)) {
             matches.push({
                 field: 'refId',
                 fieldValue: `${s.refId || ''}`,
             });
         }
 
-        if (`${s.label || ''}`.toLowerCase().match(searchRegex)) {
+        if (`${s.label || ''}`.match(searchRegex)) {
             matches.push({
                 field: 'label',
                 fieldValue: s.label!,
             });
         }
 
-        if (`${s.sectionTitle || ''}`.toLowerCase().match(searchRegex)) {
+        if (`${s.sectionTitle || ''}`.match(searchRegex)) {
             matches.push({
                 field: 'sectionTitle',
                 fieldValue: s.sectionTitle!,
             });
         }
 
-        if (`${s.previewTitle || ''}`.toLowerCase().match(searchRegex)) {
+        if (`${s.previewTitle || ''}`.match(searchRegex)) {
             matches.push({
                 field: 'previewTitle',
                 fieldValue: s.previewTitle!,
             });
         }
 
-        if (`${s.previewPrintTitle || ''}`.toLowerCase().match(searchRegex)) {
+        if (`${s.previewPrintTitle || ''}`.match(searchRegex)) {
             matches.push({
                 field: 'previewPrintTitle',
                 fieldValue: s.previewPrintTitle!,
             });
         }
 
-        if (`${s.condition || ''}`.toLowerCase().match(searchRegex)) {
+        if (`${s.condition || ''}`.match(searchRegex)) {
             matches.push({
                 field: 'condition',
                 fieldValue: s.condition!,
@@ -162,7 +163,7 @@ export function parseScriptsSearchResults({
         }
 
         (s.fields || []).map((f: ScriptField, i) => {
-            if (`${f.key || ''}`.toLowerCase().match(searchRegex)) {
+            if (`${f.key || ''}`.match(searchRegex)) {
                 matches.push({
                     field: 'field_key',
                     fieldIndex: i,
@@ -170,7 +171,7 @@ export function parseScriptsSearchResults({
                 });
             }
 
-            if (`${f.label || ''}`.toLowerCase().match(searchRegex)) {
+            if (`${f.label || ''}`.match(searchRegex)) {
                 matches.push({
                     field: 'field_label',
                     fieldIndex: i,
@@ -178,7 +179,7 @@ export function parseScriptsSearchResults({
                 });
             }
 
-            if (`${f.condition || ''}`.toLowerCase().match(searchRegex)) {
+            if (`${f.condition || ''}`.match(searchRegex)) {
                 matches.push({
                     field: 'field_condition',
                     fieldIndex: i,
@@ -187,7 +188,7 @@ export function parseScriptsSearchResults({
             }
 
             (f.items || []).map((f, j) => {
-                if (`${f.value || ''}`.toLowerCase().match(searchRegex)) {
+                if (`${f.value || ''}`.match(searchRegex)) {
                     matches.push({
                         field: 'field_item_key',
                         fieldIndex: i,
@@ -196,7 +197,7 @@ export function parseScriptsSearchResults({
                     });
                 }
 
-                if (`${f.label || ''}`.toLowerCase().match(searchRegex)) {
+                if (`${f.label || ''}`.match(searchRegex)) {
                     matches.push({
                         field: 'field_item_label',
                         fieldIndex: i,
@@ -204,11 +205,29 @@ export function parseScriptsSearchResults({
                         fieldValue: f.label as string,
                     });
                 }
+
+                if (f.enterValueManually && manualEntrySearchText.match(searchRegex)) {
+                    matches.push({
+                        field: 'field_item_manual_entry',
+                        fieldIndex: i,
+                        fieldItemIndex: j,
+                        fieldValue: 'Enter value manually',
+                    });
+                }
+
+                if (`${f.enterValueManuallyLabel || ''}`.match(searchRegex)) {
+                    matches.push({
+                        field: 'field_item_manual_label',
+                        fieldIndex: i,
+                        fieldItemIndex: j,
+                        fieldValue: `${f.enterValueManuallyLabel || ''}`,
+                    });
+                }
             });
         });
 
         (s.items || []).map((f, i) => {
-            if (`${f.id || ''}`.toLowerCase().match(searchRegex)) {
+            if (`${f.id || ''}`.match(searchRegex)) {
                 matches.push({
                     field: 'item_id',
                     fieldIndex: i,
@@ -216,7 +235,7 @@ export function parseScriptsSearchResults({
                 });
             }
 
-            if (`${f.key || ''}`.toLowerCase().match(searchRegex)) {
+            if (`${f.key || ''}`.match(searchRegex)) {
                 matches.push({
                     field: 'item_key',
                     fieldIndex: i,
@@ -224,17 +243,33 @@ export function parseScriptsSearchResults({
                 });
             }
 
-            if (`${f.label || ''}`.toLowerCase().match(searchRegex)) {
+            if (`${f.label || ''}`.match(searchRegex)) {
                 matches.push({
                     field: 'item_label',
                     fieldIndex: i,
                     fieldValue: f.label,
                 });
             }
+
+            if (f.enterValueManually && manualEntrySearchText.match(searchRegex)) {
+                matches.push({
+                    field: 'item_manual_entry',
+                    fieldIndex: i,
+                    fieldValue: 'Enter value manually',
+                });
+            }
+
+            if (`${f.enterValueManuallyLabel || ''}`.match(searchRegex)) {
+                matches.push({
+                    field: 'item_manual_label',
+                    fieldIndex: i,
+                    fieldValue: `${f.enterValueManuallyLabel || ''}`,
+                });
+            }
         });
 
         (s.drugs || []).map((f, i) => {
-            if (`${f.key || ''}`.toLowerCase().match(searchRegex)) {
+            if (`${f.key || ''}`.match(searchRegex)) {
                 matches.push({
                     field: 'drug',
                     fieldIndex: i,
@@ -244,7 +279,7 @@ export function parseScriptsSearchResults({
         });
 
         (s.fluids || []).map((f, i) => {
-            if (`${f.key || ''}`.toLowerCase().match(searchRegex)) {
+            if (`${f.key || ''}`.match(searchRegex)) {
                 matches.push({
                     field: 'fluid',
                     fieldIndex: i,
@@ -254,7 +289,7 @@ export function parseScriptsSearchResults({
         });
 
         (s.feeds || []).map((f, i) => {
-            if (`${f.key || ''}`.toLowerCase().match(searchRegex)) {
+            if (`${f.key || ''}`.match(searchRegex)) {
                 matches.push({
                     field: 'feed',
                     fieldIndex: i,
@@ -298,21 +333,21 @@ export function parseScriptsSearchResults({
     diagnoses.forEach(s => {
         const matches: ScriptsSearchResultsItem['matches'] = [];
 
-        if (`${s.name || ''}`.toLowerCase().match(searchRegex)) {
+        if (`${s.name || ''}`.match(searchRegex)) {
             matches.push({
                 field: 'name',
                 fieldValue: s.name!,
             });
         }
 
-        if (`${s.key || ''}`.toLowerCase().match(searchRegex)) {
+        if (`${s.key || ''}`.match(searchRegex)) {
             matches.push({
                 field: 'key',
                 fieldValue: s.key!,
             });
         }
 
-        if (`${s.expression || ''}`.toLowerCase().match(searchRegex)) {
+        if (`${s.expression || ''}`.match(searchRegex)) {
             matches.push({
                 field: 'expression',
                 fieldValue: s.expression!,
@@ -320,7 +355,7 @@ export function parseScriptsSearchResults({
         }
 
         (s.symptoms || []).map((f, i) => {
-            if (`${f.key || ''}`.toLowerCase().match(searchRegex)) {
+            if (`${f.key || ''}`.match(searchRegex)) {
                 matches.push({
                     field: 'diagnosis_symptom_key',
                     fieldIndex: i,
@@ -328,7 +363,7 @@ export function parseScriptsSearchResults({
                 });
             }
 
-            if (`${f.name || ''}`.toLowerCase().match(searchRegex)) {
+            if (`${f.name || ''}`.match(searchRegex)) {
                 matches.push({
                     field: 'diagnosis_symptom_name',
                     fieldIndex: i,
@@ -336,7 +371,7 @@ export function parseScriptsSearchResults({
                 });
             }
 
-            if (`${f.expression || ''}`.toLowerCase().match(searchRegex)) {
+            if (`${f.expression || ''}`.match(searchRegex)) {
                 matches.push({
                     field: 'diagnosis_symptom_expression',
                     fieldIndex: i,
@@ -401,6 +436,10 @@ export const scriptsSearchResultsFilters = [
         value: 'condition',
         label: 'Conditional expression only',
     },
+    {
+        value: 'manual_entry',
+        label: 'Manual entry only',
+    },
 ] as const;
 
 export type ScriptsSearchResultsFilter = ArrayElement<typeof scriptsSearchResultsFilters>['value'];
@@ -421,6 +460,10 @@ const matchedFieldFilterMap: Record<string, string> = {
     condition: 'condition',
     field_condition: 'condition',
     item_condition: 'condition',
+    field_item_manual_entry: 'manual_entry',
+    item_manual_entry: 'manual_entry',
+    field_item_manual_label: 'manual_entry',
+    item_manual_label: 'manual_entry',
 };
 
 export function filterScriptsSearchResults({ searchValue, filter, results, }: {
@@ -460,3 +503,4 @@ export function filterScriptsSearchResults({ searchValue, filter, results, }: {
 
     return filtered;
 }
+

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,5 +1,5 @@
-const START_QUOTE_CHARS = ['"', '\u201C']
-const END_QUOTE_CHARS = ['"', '\u201D']
+const START_QUOTE_CHARS = ['"', "'", '\u201C', '\u2018']
+const END_QUOTE_CHARS = ['"', "'", '\u201D', '\u2019']
 
 /** Escape user input for safe literal use in RegExp constructors. */
 export function escapeRegex(value: string) {
@@ -23,7 +23,7 @@ export function normalizeSearchTerm(rawValue: string) {
   const unquotedValue = wrappedInQuotes ? trimmedValue.slice(1, -1) : trimmedValue
 
   return {
-    normalizedValue: unquotedValue.trim().toLowerCase(),
+    normalizedValue: wrappedInQuotes ? unquotedValue.trim() : unquotedValue.trim().toLowerCase(),
     isExactMatch: wrappedInQuotes,
   }
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -52,6 +52,7 @@ export type ScriptItem = {
     confidential: boolean;
     checked: boolean;
     enterValueManually?: boolean;
+    enterValueManuallyLabel?: string;
     severity_order: string;
     summary: string;
     key: string;
@@ -111,6 +112,7 @@ export type ScriptField = {
         exclusiveGroup?: string;
         forbidWith?: string[];
         enterValueManually?: boolean;
+        enterValueManuallyLabel?: string;
         keyId?: string;
     }[];
 };


### PR DESCRIPTION
## TICKETS
[NEOAPP-1255](https://neotree.atlassian.net/browse/NEOAPP-1255)
[NEOAPP-1165](https://neotree.atlassian.net/browse/NEOAPP-1165)

This PR adds end-to-end support for labeling manual-entry options, improves editor UX for finding those fields quickly, and updates search semantics so quoted exact search is case-sensitive (with both double and single quotes supported).