### PR TITLE
making the enter value manually label field mandatory

### DIFF
--- a/app/(dashboard)/(scripts)/components/screens/fields.tsx
+++ b/app/(dashboard)/(scripts)/components/screens/fields.tsx
@@ -151,7 +151,7 @@ export function Fields({
 
             <DataTable 
                 title="Fields"
-                sortable={!disabled}
+                sortable={!disabled && !manualOnly && !missingManualLabelOnly}
                 selectable={!disabled}
                 onSort={onSort}
                 selectedIndexes={selectedIndexes}

--- a/app/(dashboard)/(scripts)/components/screens/item.tsx
+++ b/app/(dashboard)/(scripts)/components/screens/item.tsx
@@ -123,6 +123,7 @@ export function Item<P = {}>({
     register,
     handleSubmit,
     setValue,
+    formState: { errors },
   } = useForm({
     defaultValues: getDefaultValues(),
   })
@@ -153,6 +154,12 @@ export function Item<P = {}>({
   }, [items, item?.itemId])
 
   const onSave = handleSubmit(async (data) => {
+    const manualLabel = `${data.enterValueManuallyLabel || ""}`.trim()
+    data = {
+      ...data,
+      enterValueManuallyLabel: data.enterValueManually ? manualLabel : "",
+    }
+
     if (!isEmpty(itemIndex) && item) {
       form.setValue(
         "items",
@@ -470,14 +477,26 @@ export function Item<P = {}>({
 
                         {enterValueManually && (
                           <div>
-                            <Label htmlFor="enterValueManuallyLabel">Manual value label</Label>
+                            <Label htmlFor="enterValueManuallyLabel">Manual value label *</Label>
                             <Input
-                              {...register("enterValueManuallyLabel", { disabled, required: enterValueManually })}
+                              {...register("enterValueManuallyLabel", {
+                                disabled,
+                                validate: (value) => {
+                                  if (!enterValueManually) return true
+                                  return !!`${value || ""}`.trim() || "Manual value label is required."
+                                },
+                              })}
                               name="enterValueManuallyLabel"
+                              error={!disabled && !!errors.enterValueManuallyLabel}
                             />
                             <span className="text-xs text-muted-foreground">
                               Shown to users when they enter a custom value for this option.
                             </span>
+                            {!!errors.enterValueManuallyLabel && (
+                              <span className="text-xs text-destructive">
+                                {`${errors.enterValueManuallyLabel.message || ""}`}
+                              </span>
+                            )}
                           </div>
                         )}
                       </>

--- a/lib/scripts-search.ts
+++ b/lib/scripts-search.ts
@@ -70,7 +70,13 @@ export function parseScriptsSearchResults({
     const escapedSearchValue = escapeRegex(normalizedValue);
     const pattern = isExactMatch ? `^${escapedSearchValue}$` : escapedSearchValue;
     const searchRegex = new RegExp(pattern, isExactMatch ? "" : "i");
-    const manualEntrySearchText = 'manual entry enter value manually custom value other specify';
+    const manualEntrySearchTerms = [
+        'manual entry',
+        'enter value manually',
+        'custom value',
+        'other',
+        'specify',
+    ];
 
     const resultsMap: Record<string, ScriptsSearchResultsItem> = {};
 
@@ -206,7 +212,7 @@ export function parseScriptsSearchResults({
                     });
                 }
 
-                if (f.enterValueManually && manualEntrySearchText.match(searchRegex)) {
+                if (f.enterValueManually && manualEntrySearchTerms.some(term => term.match(searchRegex))) {
                     matches.push({
                         field: 'field_item_manual_entry',
                         fieldIndex: i,
@@ -251,7 +257,7 @@ export function parseScriptsSearchResults({
                 });
             }
 
-            if (f.enterValueManually && manualEntrySearchText.match(searchRegex)) {
+            if (f.enterValueManually && manualEntrySearchTerms.some(term => term.match(searchRegex))) {
                 matches.push({
                     field: 'item_manual_entry',
                     fieldIndex: i,

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,5 +1,9 @@
-const START_QUOTE_CHARS = ['"', "'", '\u201C', '\u2018']
-const END_QUOTE_CHARS = ['"', "'", '\u201D', '\u2019']
+const QUOTE_PAIRS: Record<string, string> = {
+  '"': '"',
+  "'": "'",
+  "\u201C": "\u201D",
+  "\u2018": "\u2019",
+}
 
 /** Escape user input for safe literal use in RegExp constructors. */
 export function escapeRegex(value: string) {
@@ -16,9 +20,10 @@ export function normalizeSearchTerm(rawValue: string) {
     }
   }
 
-  const startsWithQuote = START_QUOTE_CHARS.includes(trimmedValue[0])
-  const endsWithQuote = END_QUOTE_CHARS.includes(trimmedValue[trimmedValue.length - 1])
-  const wrappedInQuotes = trimmedValue.length > 1 && startsWithQuote && endsWithQuote
+  const startQuote = trimmedValue[0]
+  const endQuote = trimmedValue[trimmedValue.length - 1]
+  const expectedEndQuote = QUOTE_PAIRS[startQuote]
+  const wrappedInQuotes = trimmedValue.length > 1 && !!expectedEndQuote && expectedEndQuote === endQuote
 
   const unquotedValue = wrappedInQuotes ? trimmedValue.slice(1, -1) : trimmedValue
 


### PR DESCRIPTION
This PR improves how manual-entry options are authored and discovered across the scripts editor. It introduces a required manual-entry label workflow, adds better discovery/filtering in fields and list views, and hardens search behavior (including exact-match semantics).