### PR TITLE
added more fields on scripts metadat

### DIFF
--- a/app/(ops)/scripts/[scriptId]/metadata/components/actions.tsx
+++ b/app/(ops)/scripts/[scriptId]/metadata/components/actions.tsx
@@ -30,9 +30,38 @@ export function ScriptMetaActions({ data }: {
                 Optional: string;
                 'Field Condition': string;
                 'Screen Condition': string;
+                'Skip To Screen Conditional Expression': string;
+                'Skip To Screen': string;
+                'Disable other options if selected': string;
+                'Forbid With': string;
+                'Management Metadata': string;
             }[];
 
             script.screens.forEach(screen => {
+                if ((screen.type === 'management') && !screen.fields.length) {
+                    worksheetData.push({
+                        Script: script.title,
+                        Hospital: script.hospitalName || '',
+                        Screen: screen.title,
+                        'Screen Ref': screen.ref || '',
+                        'Screen Type': screen.type || '',
+                        Key: '',
+                        Label: '',
+                        'Data Type': '',
+                        'Value': '',
+                        'Value Label': '',
+                        Confidential: '',
+                        Optional: '',
+                        'Field Condition': '',
+                        'Screen Condition': screen.condition || '',
+                        'Skip To Screen Conditional Expression': screen.skipToCondition || '',
+                        'Skip To Screen': screen.skipToScreen ? JSON.stringify(screen.skipToScreen) : '',
+                        'Disable other options if selected': '',
+                        'Forbid With': '',
+                        'Management Metadata': screen.managementMetadata ? JSON.stringify(screen.managementMetadata) : '',
+                    });
+                }
+
                 screen.fields.forEach(f => {
                     worksheetData.push({
                         Script: script.title,
@@ -49,6 +78,15 @@ export function ScriptMetaActions({ data }: {
                         Optional: f.optional ? 'Yes' : 'No',
                         'Field Condition': f.condition || '',
                         'Screen Condition': screen.condition || '',
+                        'Skip To Screen Conditional Expression': screen.skipToCondition || '',
+                        'Skip To Screen': screen.skipToScreen ? JSON.stringify(screen.skipToScreen) : '',
+                        'Disable other options if selected': typeof f.disableOtherOptionsIfSelected === 'boolean'
+                            ? (f.disableOtherOptionsIfSelected ? 'Yes' : 'No')
+                            : '',
+                        'Forbid With': f.forbidWith?.join(', ') || '',
+                        'Management Metadata': screen.type === 'management' && screen.managementMetadata
+                            ? JSON.stringify(screen.managementMetadata)
+                            : '',
                     });
                 });
             });
@@ -71,6 +109,8 @@ export function ScriptMetaActions({ data }: {
                 'Value': string;
                 'Value Label': string;
                 Condition: string;
+                'Disable other options if selected': string;
+                'Forbid With': string;
             }[];
 
             script.diagnoses.forEach(d => {
@@ -87,6 +127,8 @@ export function ScriptMetaActions({ data }: {
                     Value: d.key,
                     'Value Label': d.name,
                     Condition: `${d.expression || ''}`,
+                    'Disable other options if selected': '',
+                    'Forbid With': '',
                 });
             });
 

--- a/databases/queries/scripts/_get_scripts_metadata.ts
+++ b/databases/queries/scripts/_get_scripts_metadata.ts
@@ -2,7 +2,7 @@ import { and, inArray, isNull } from "drizzle-orm";
 
 import db from "@/databases/pg/drizzle";
 import { scripts, screens, hospitals, scriptsDrafts } from "@/databases/pg/schema";
-import { ScriptField, ScriptItem } from "@/types";
+import { ScriptField, ScriptImage, ScriptItem } from "@/types";
 import * as uuid from "uuid";
 
 export type GetScriptsMetadataParams = {
@@ -22,6 +22,36 @@ export type GetScriptsMetadataResponse = {
             title: string;
             ref: string;
             condition?: typeof screens.$inferSelect['condition'];
+            skipToCondition?: typeof screens.$inferSelect['skipToCondition'];
+            skipToScreen?: {
+                screenId: string;
+                position: number | null;
+            } | null;
+            managementMetadata?: {
+                actionText: string;
+                contentText: string;
+                infoText: string;
+                title: string;
+                title1: string;
+                title2: string;
+                title3: string;
+                title4: string;
+                text1: string;
+                text2: string;
+                text3: string;
+                instructions: string;
+                instructions2: string;
+                instructions3: string;
+                instructions4: string;
+                notes: string;
+                refKey: string;
+                images: {
+                    contentTextImage: null | ScriptImage;
+                    image1: null | ScriptImage;
+                    image2: null | ScriptImage;
+                    image3: null | ScriptImage;
+                };
+            } | null;
             fields: {
                 label: string;
                 key: string;
@@ -34,6 +64,8 @@ export type GetScriptsMetadataResponse = {
                 minValue?: string | number | null;
                 maxValue?: string | number | null;
                 condition?: string | null;
+                disableOtherOptionsIfSelected?: boolean;
+                forbidWith?: string[];
             }[];
         }[];
         diagnoses: {
@@ -63,6 +95,18 @@ export type GetScriptsMetadataResponse = {
 
 export async function _getScriptsMetadata(params?: GetScriptsMetadataParams): Promise<GetScriptsMetadataResponse> {
     try {
+        const sanitizeImage = (image: unknown): null | ScriptImage => {
+            if (!image || typeof image !== "object") return null;
+            const img = image as ScriptImage;
+            return {
+                data: `${img.data || ""}`,
+                fileId: img.fileId,
+                filename: img.filename,
+                size: img.size,
+                contentType: img.contentType,
+            };
+        };
+
         const {
             scriptsIds = [],
             hospitalsIds = [],
@@ -183,6 +227,47 @@ export async function _getScriptsMetadata(params?: GetScriptsMetadataParams): Pr
                 screens: script.screens.map(screen => {
                     const items = screen.items as ScriptItem[];
                     const screenFields = screen.fields as ScriptField[];
+                    const skipToScreen = !screen.skipToScreenId
+                        ? null
+                        : (() => {
+                            const targetScreen = script.screens.find(s => s.screenId === screen.skipToScreenId);
+                            const targetScreenIndex = script.screens.findIndex(s => s.screenId === screen.skipToScreenId);
+                            if (!targetScreen) {
+                                return {
+                                    screenId: screen.skipToScreenId,
+                                    position: null,
+                                };
+                            }
+                            return {
+                                screenId: targetScreen.screenId,
+                                position: targetScreenIndex >= 0 ? targetScreenIndex + 1 : null,
+                            };
+                        })();
+                    const managementMetadata = screen.type !== 'management' ? null : {
+                        actionText: `${screen.actionText || ''}`,
+                        contentText: `${screen.contentText || ''}`,
+                        infoText: `${screen.infoText || ''}`,
+                        title: `${screen.title || ''}`,
+                        title1: `${screen.title1 || ''}`,
+                        title2: `${screen.title2 || ''}`,
+                        title3: `${screen.title3 || ''}`,
+                        title4: `${screen.title4 || ''}`,
+                        text1: `${screen.text1 || ''}`,
+                        text2: `${screen.text2 || ''}`,
+                        text3: `${screen.text3 || ''}`,
+                        instructions: `${screen.instructions || ''}`,
+                        instructions2: `${screen.instructions2 || ''}`,
+                        instructions3: `${screen.instructions3 || ''}`,
+                        instructions4: `${screen.instructions4 || ''}`,
+                        notes: `${screen.notes || ''}`,
+                        refKey: `${screen.refKey || ''}`,
+                        images: {
+                            contentTextImage: sanitizeImage(screen.contentTextImage),
+                            image1: sanitizeImage(screen.image1),
+                            image2: sanitizeImage(screen.image2),
+                            image3: sanitizeImage(screen.image3),
+                        },
+                    };
 
                     let fields: (GetScriptsMetadataResponse['data'][0]['screens'][0]['fields'][0])[] = [{
                         label: screen.label,
@@ -299,7 +384,12 @@ export async function _getScriptsMetadata(params?: GetScriptsMetadataParams): Pr
                                     let dataType = 'dropdown';
                                     if (f.type === 'multi_select') dataType = 'multi_select';
 
-                                    let opts = (f.values || '').split('\n')
+                                    let opts: {
+                                        value: string;
+                                        label: string;
+                                        disableOtherOptionsIfSelected?: boolean;
+                                        forbidWith?: string[];
+                                    }[] = (f.values || '').split('\n')
                                         .map((v = '') => v.trim())
                                         .filter((v: any) => v)
                                         .map((v: any) => {
@@ -311,6 +401,13 @@ export async function _getScriptsMetadata(params?: GetScriptsMetadataParams): Pr
                                         opts = dropdownItems.map(o => ({
                                             value: `${o.value || ''}`,
                                             label: `${o.label || ''}`,
+                                            disableOtherOptionsIfSelected: !!o.exclusive,
+                                            forbidWith: (o.forbidWith || [])
+                                                .map(forbidWithItemId =>
+                                                    dropdownItems.find(item => item.itemId === forbidWithItemId)?.value
+                                                )
+                                                .filter((v): v is string | number => !!v)
+                                                .map(v => `${v}`),
                                         }));
                                     }
 
@@ -324,6 +421,8 @@ export async function _getScriptsMetadata(params?: GetScriptsMetadataParams): Pr
                                             valueLabel: o.label,
                                             optional: f.optional,
                                             confidential: f.confidential,
+                                            disableOtherOptionsIfSelected: dataType === 'multi_select' ? !!o.disableOtherOptionsIfSelected : undefined,
+                                            forbidWith: dataType === 'multi_select' ? (o.forbidWith || []) : undefined,
                                         };
                                     });
                                 }
@@ -370,6 +469,10 @@ export async function _getScriptsMetadata(params?: GetScriptsMetadataParams): Pr
                                 valueLabel: item.label,
                                 optional: screen.skippable,
                                 confidential: screen.confidential,
+                                disableOtherOptionsIfSelected: !!item.exclusive,
+                                forbidWith: (item.forbidWith || [])
+                                    .map(forbidWithItemId => items.find(option => option.itemId === forbidWithItemId)?.id)
+                                    .filter((v): v is string => !!v),
                             }));
                             break;
                         default:
@@ -382,6 +485,9 @@ export async function _getScriptsMetadata(params?: GetScriptsMetadataParams): Pr
                         title: screen.title,
                         ref: screen.refId,
                         condition: screen.condition,
+                        skipToCondition: screen.skipToCondition,
+                        skipToScreen,
+                        managementMetadata,
                         fields,
                     };
                 }),


### PR DESCRIPTION
## Summary
This PR expands the **Scripts Metadata** output (JSON + Excel) to support richer flow-control and option-level metadata, and adds full metadata visibility for management screens.

## What changed

### 1. Skip-to-screen metadata
- Added `skipToCondition` to screen metadata.
- Changed `skipToScreen` from a display string to a structured object:
  - `{ screenId: string, position: number | null }`
- Fixed `skipToScreen.position` to use the **actual screen order in the metadata list** (1-based index), not raw DB position values.

### 2. Multi-select option metadata
- Added option-level metadata fields in metadata output:
  - `disableOtherOptionsIfSelected` (mapped from `exclusive`)
  - `forbidWith` (mapped to related option values/ids as available)
- Applied for:
  - screen-level `multi_select` items
  - form field `multi_select` options (`f.items`)

### 3. Excel export enhancements (Screens sheet)
- Added columns:
  - `Skip To Screen Conditional Expression`
  - `Skip To Screen`
  - `Disable other options if selected`
  - `Forbid With`
  - `Management Metadata`
- `Skip To Screen` is exported as JSON string when present.
- Added management-screen row export even when `fields` is empty (previously these screens could be omitted).

### 4. Diagnoses sheet update
- Added columns for consistency:
  - `Disable other options if selected`
  - `Forbid With`
- Values are currently blank for diagnosis rows.

### 5. Management screen full metadata
- Added `managementMetadata` for `management` screens, including:
  - titles (`title`, `title1..title4`)
  - text fields (`actionText`, `contentText`, `infoText`, `text1..text3`)
  - instructions (`instructions`, `instructions2..instructions4`)
  - `notes`, `refKey`
  - images (`contentTextImage`, `image1`, `image2`, `image3`)