### PR TITLE
Enhance Scripts Metadata output for diagnoses and add collapsible JSON viewer

### DIFF
--- a/app/(ops)/scripts/[scriptId]/metadata/components/actions.tsx
+++ b/app/(ops)/scripts/[scriptId]/metadata/components/actions.tsx
@@ -100,11 +100,22 @@ export function ScriptMetaActions({ data }: {
                 Script: string;
                 Hospital: string;
                 'Diagnosis Name': string;
+                'Diagnosis Description': string;
                 Key: string;
+                'Key ID': string;
                 Label: string;
+                Position: string;
+                Source: string;
                 'Severity Order': string;
                 Expression: string;
                 'Expression Meaning': string;
+                Symptoms: string;
+                'Text 1': string;
+                'Text 2': string;
+                'Text 3': string;
+                'Image 1': string;
+                'Image 2': string;
+                'Image 3': string;
                 'Data Type': string;
                 'Value': string;
                 'Value Label': string;
@@ -118,11 +129,22 @@ export function ScriptMetaActions({ data }: {
                     Script: script.title,
                     Hospital: script.hospitalName || '',
                     'Diagnosis Name': d.name,
+                    'Diagnosis Description': `${d.description || ''}`,
                     Key: d.key,
+                    'Key ID': `${d.keyId || ''}`,
                     Label: d.name,
+                    Position: `${d.position || ''}`,
+                    Source: `${d.source || ''}`,
                     'Severity Order': `${d.severityOrder || ''}`,
                     Expression: `${d.expression || ''}`,
                     'Expression Meaning': `${d.expressionMeaning || ''}`,
+                    Symptoms: JSON.stringify(d.symptoms || []),
+                    'Text 1': `${d.text1 || ''}`,
+                    'Text 2': `${d.text2 || ''}`,
+                    'Text 3': `${d.text3 || ''}`,
+                    'Image 1': d.image1 ? JSON.stringify(d.image1) : '',
+                    'Image 2': d.image2 ? JSON.stringify(d.image2) : '',
+                    'Image 3': d.image3 ? JSON.stringify(d.image3) : '',
                     'Data Type': 'diagnosis',
                     Value: d.key,
                     'Value Label': d.name,

--- a/app/(ops)/scripts/[scriptId]/metadata/components/json-viewer.tsx
+++ b/app/(ops)/scripts/[scriptId]/metadata/components/json-viewer.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState } from "react";
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+type Props = {
+    data: JsonValue;
+};
+
+function isObject(value: JsonValue): value is { [key: string]: JsonValue } {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toJsonPrimitive(value: JsonPrimitive) {
+    if (typeof value === 'string') return JSON.stringify(value);
+    if (typeof value === 'number' || typeof value === 'boolean') return `${value}`;
+    return 'null';
+}
+
+function JsonLine({
+    value,
+    depth = 0,
+    keyName,
+    isLast = true,
+}: {
+    value: JsonValue;
+    depth?: number;
+    keyName?: string;
+    isLast?: boolean;
+}) {
+    const indent = '  '.repeat(depth);
+    const keyPrefix = typeof keyName === 'string' ? `${JSON.stringify(keyName)}: ` : '';
+    const comma = isLast ? '' : ',';
+
+    if (!Array.isArray(value) && !isObject(value)) {
+        return <div>{indent}{keyPrefix}{toJsonPrimitive(value)}{comma}</div>;
+    }
+
+    const isArray = Array.isArray(value);
+    const openToken = isArray ? '[' : '{';
+    const closeToken = isArray ? ']' : '}';
+    const entries = isArray
+        ? value.map((item, index) => [String(index), item] as const)
+        : Object.entries(value);
+
+    if (!entries.length) return <div>{indent}{keyPrefix}{openToken}{closeToken}{comma}</div>;
+
+    const [open, setOpen] = useState(true);
+
+    return (
+        <>
+            <div
+                className="cursor-pointer select-none"
+                onClick={() => setOpen(prev => !prev)}
+            >
+                {indent}{open ? '▼' : '▶'} {keyPrefix}
+                {open ? openToken : `${openToken}...${closeToken}`}{comma}
+            </div>
+
+            {open && (
+                <>
+                    {entries.map(([entryKey, entryValue], index) => (
+                        <JsonLine
+                            key={`${entryKey}.${index}`}
+                            value={entryValue}
+                            depth={depth + 1}
+                            keyName={isArray ? undefined : entryKey}
+                            isLast={index === entries.length - 1}
+                        />
+                    ))}
+                    <div>{indent}{closeToken}{comma}</div>
+                </>
+            )}
+        </>
+    );
+}
+
+export function JsonViewer({ data }: Props) {
+    return (
+        <pre className="font-mono text-sm whitespace-pre-wrap">
+            <JsonLine value={data} />
+        </pre>
+    );
+}

--- a/app/(ops)/scripts/[scriptId]/metadata/page.tsx
+++ b/app/(ops)/scripts/[scriptId]/metadata/page.tsx
@@ -1,5 +1,6 @@
 import { getScriptsMetadata } from "@/app/actions/scripts";
 import { ScriptMetaActions } from './components/actions';
+import { JsonViewer } from "./components/json-viewer";
 
 type Props = {
     params: {
@@ -16,25 +17,21 @@ export default async function OpsScripyPage({ params: { scriptId }, }: Props) {
 
     if (scriptsMeta.errors) return <h1 className="text-lg text-danger">{scriptsMeta.errors.join(', ')}</h1>;
 
+    const metadataData = scriptsMeta.data.map((s) => {
+        return {
+            ...s,
+            screens: s.screens.map((screen, screenIndex) => {
+                return {
+                    ...screen,
+                    position: screenIndex + 1,
+                };
+            }),
+        };
+    });
+
     return (
         <>
-            <pre>
-                {JSON.stringify(
-                    scriptsMeta.data.map((s, i) => {
-                        return {
-                            ...s,
-                            screens: s.screens.map((screen, screenIndex) => {
-                                return {
-                                    ...screen,
-                                    position: screenIndex + 1,
-                                };
-                            }),
-                        };
-                    }), 
-                    null, 
-                    4
-                )}
-            </pre>
+            <JsonViewer data={metadataData} />
 
             <ScriptMetaActions data={scriptsMeta.data} />
         </>

--- a/databases/queries/scripts/_get_scripts_metadata.ts
+++ b/databases/queries/scripts/_get_scripts_metadata.ts
@@ -2,7 +2,7 @@ import { and, inArray, isNull } from "drizzle-orm";
 
 import db from "@/databases/pg/drizzle";
 import { scripts, screens, hospitals, scriptsDrafts } from "@/databases/pg/schema";
-import { ScriptField, ScriptImage, ScriptItem } from "@/types";
+import { DiagnosisSymptom, ScriptField, ScriptImage, ScriptItem } from "@/types";
 import * as uuid from "uuid";
 
 export type GetScriptsMetadataParams = {
@@ -72,10 +72,20 @@ export type GetScriptsMetadataResponse = {
             diagnosisId: string;
             name: string;
             key: string;
+            keyId: string;
+            position: number | null;
+            source: string | null;
             severityOrder?: string | number | null;
             expression?: string | number | null;
             expressionMeaning?: string | null;
             description?: string | null;
+            text1: string | null;
+            text2: string | null;
+            text3: string | null;
+            image1: null | ScriptImage;
+            image2: null | ScriptImage;
+            image3: null | ScriptImage;
+            symptoms: DiagnosisSymptom[];
             fields: {
                 label: string;
                 key: string;
@@ -213,14 +223,26 @@ export async function _getScriptsMetadata(params?: GetScriptsMetadataParams): Pr
                 title: script.title,
                 hospitalName: hospital?.name || '',
                 diagnoses: script.diagnoses.map(d => {
+                    const symptoms = Array.isArray(d.symptoms) ? d.symptoms : [];
+
                     return {
                         diagnosisId: d.diagnosisId,
                         name: d.name,
                         key: d.key || d.name,
+                        keyId: d.keyId || '',
+                        position: d.position ?? null,
+                        source: d.source || '',
                         severityOrder: d.severityOrder || '',
                         expression: d.expression || '',
                         expressionMeaning: d.expressionMeaning || '',
                         description: d.description || '',
+                        text1: d.text1 || '',
+                        text2: d.text2 || '',
+                        text3: d.text3 || '',
+                        image1: sanitizeImage(d.image1),
+                        image2: sanitizeImage(d.image2),
+                        image3: sanitizeImage(d.image3),
+                        symptoms,
                         fields: [],
                     };
                 }),


### PR DESCRIPTION
## Summary
This PR improves the Ops Scripts Metadata page by making diagnosis metadata more complete while keeping the payload aligned with original source fields, and by replacing the raw JSON dump with a collapsible JSON view that preserves a plain JSON-like look.
