### PR TITLE
Enhance Scripts Metadata output: normalize options, remove duplication, and simplify shape

### DIFF
--- a/app/(dashboard)/data-keys/components/form.tsx
+++ b/app/(dashboard)/data-keys/components/form.tsx
@@ -557,9 +557,7 @@ function Form({
                                 />
                                 <Label htmlFor="dataKeyConfidential">Confidential</Label>
                             </div>
-                            <span className="text-xs text-muted-foreground">
-                                Fields and items that reference this Data Key inherit this setting.
-                            </span>
+            
                         </div>
 
                         <Controller

--- a/app/(ops)/scripts/[scriptId]/metadata/components/actions.tsx
+++ b/app/(ops)/scripts/[scriptId]/metadata/components/actions.tsx
@@ -29,7 +29,10 @@ export function ScriptMetaActions({ data }: {
                 Confidential: string;
                 Optional: string;
                 'Field Condition': string;
+                'Field Options': string;
                 'Screen Condition': string;
+                'Item Condition': string;
+                'Item Options': string;
                 'Skip To Screen Conditional Expression': string;
                 'Skip To Screen': string;
                 'Disable other options if selected': string;
@@ -53,7 +56,10 @@ export function ScriptMetaActions({ data }: {
                         Confidential: '',
                         Optional: '',
                         'Field Condition': '',
+                        'Field Options': '',
                         'Screen Condition': screen.condition || '',
+                        'Item Condition': '',
+                        'Item Options': '',
                         'Skip To Screen Conditional Expression': screen.skipToCondition || '',
                         'Skip To Screen': screen.skipToScreen ? JSON.stringify(screen.skipToScreen) : '',
                         'Disable other options if selected': '',
@@ -77,7 +83,10 @@ export function ScriptMetaActions({ data }: {
                         Confidential: f.confidential ? 'Yes' : 'No',
                         Optional: f.optional ? 'Yes' : 'No',
                         'Field Condition': f.condition || '',
+                        'Field Options': f.options?.length ? JSON.stringify(f.options) : '',
                         'Screen Condition': screen.condition || '',
+                        'Item Condition': '',
+                        'Item Options': '',
                         'Skip To Screen Conditional Expression': screen.skipToCondition || '',
                         'Skip To Screen': screen.skipToScreen ? JSON.stringify(screen.skipToScreen) : '',
                         'Disable other options if selected': typeof f.disableOtherOptionsIfSelected === 'boolean'

--- a/databases/queries/scripts/_get_scripts_metadata.ts
+++ b/databases/queries/scripts/_get_scripts_metadata.ts
@@ -57,15 +57,31 @@ export type GetScriptsMetadataResponse = {
                 key: string;
                 type: string;
                 dataType: string | null;
-                value: any;
-                valueLabel: null | string;
+                value?: any;
+                valueLabel?: null | string;
                 optional?: boolean;
                 confidential: boolean;
                 minValue?: string | number | null;
                 maxValue?: string | number | null;
                 condition?: string | null;
+                options?: {
+                    value: string;
+                    valueLabel: string;
+                    disabledOtherOptionsIfSelected?: boolean;
+                    forbidWIth?: string[];
+                }[];
                 disableOtherOptionsIfSelected?: boolean;
                 forbidWith?: string[];
+            }[];
+            items?: {
+                itemId: string;
+                key: string;
+                value: string;
+                label: string;
+                valueLabel?: string;
+                disabledOtherOptionsIfSelected?: boolean;
+                forbidWIth?: string[];
+                condition?: string | null;
             }[];
         }[];
         diagnoses: {
@@ -86,18 +102,25 @@ export type GetScriptsMetadataResponse = {
             image2: null | ScriptImage;
             image3: null | ScriptImage;
             symptoms: DiagnosisSymptom[];
-            fields: {
-                label: string;
-                key: string;
-                type: string;
-                dataType: string | null;
-                value: any;
-                valueLabel: null | string;
-                optional?: boolean;
-                confidential: boolean;
-                minValue?: string | number | null;
-                maxValue?: string | number | null;
-            }[];
+                fields: {
+                    label: string;
+                    key: string;
+                    type: string;
+                    dataType: string | null;
+                value?: any;
+                valueLabel?: null | string;
+                    optional?: boolean;
+                    confidential: boolean;
+                    minValue?: string | number | null;
+                    maxValue?: string | number | null;
+                    condition?: string | null;
+                    options?: {
+                        value: string;
+                        valueLabel: string;
+                        disabledOtherOptionsIfSelected?: boolean;
+                        forbidWIth?: string[];
+                    }[];
+                }[];
         }[];
     }[],
     errors?: string[];
@@ -290,6 +313,24 @@ export async function _getScriptsMetadata(params?: GetScriptsMetadataParams): Pr
                             image3: sanitizeImage(screen.image3),
                         },
                     };
+                    const screenItems = items.map(item => ({
+                        itemId: `${item.itemId || ''}`,
+                        key: `${item.key || item.id || ''}`,
+                        value: `${item.id || ''}`,
+                        label: `${item.label || ''}`,
+                        valueLabel: `${item.label || ''}`,
+                        disabledOtherOptionsIfSelected: !!item.exclusive,
+                        forbidWIth: (item.forbidWith || [])
+                            .map(forbidWithItemId => items.find(option => option.itemId === forbidWithItemId)?.id)
+                            .filter((v): v is string => !!v),
+                        condition: `${(item as any)?.condition || ''}`,
+                    }));
+                    const screenOptions = screenItems.map(item => ({
+                        value: item.value,
+                        valueLabel: item.label,
+                        disabledOtherOptionsIfSelected: item.disabledOtherOptionsIfSelected,
+                        forbidWIth: item.forbidWIth,
+                    }));
 
                     let fields: (GetScriptsMetadataResponse['data'][0]['screens'][0]['fields'][0])[] = [{
                         label: screen.label,
@@ -309,6 +350,7 @@ export async function _getScriptsMetadata(params?: GetScriptsMetadataParams): Pr
                                         confidential: screen.confidential,
                                         minValue: screen.minValue,
                                         maxValue: screen.maxValue,
+                                        condition: screen.condition || '',
                                     };
                             }
                         })(),
@@ -324,47 +366,51 @@ export async function _getScriptsMetadata(params?: GetScriptsMetadataParams): Pr
                             break;
 
                         case 'yesno':
-                            fields = [
-                                { value: 'true', label: screen.positiveLabel || 'Yes', },
-                                { value: 'false', label: screen.negativeLabel || 'Yes', },
-                            ].map(o => {
-                                return {
-                                    label: screen.label,
-                                    key: screen.key,
-                                    type: screen.type,
-                                    dataType: 'boolean',
-                                    value: o.value,
-                                    valueLabel: o.label,
-                                    optional: screen.skippable,
-                                    confidential: screen.confidential,
-                                };
-                            });
+                            fields = [{
+                                label: screen.label,
+                                key: screen.key,
+                                type: screen.type,
+                                dataType: 'boolean',
+                                optional: screen.skippable,
+                                confidential: screen.confidential,
+                                condition: screen.condition || '',
+                                options: [
+                                    {
+                                        value: 'true',
+                                        valueLabel: screen.positiveLabel || 'Yes',
+                                    },
+                                    {
+                                        value: 'false',
+                                        valueLabel: screen.negativeLabel || 'No',
+                                    },
+                                ],
+                            }];
                             break;
 
                         case 'diagnosis':
-                            fields = items.map(item => ({
-                                value: item.id,
-                                valueLabel: item.label,
-                                label: item.label,
-                                key: item.id,
+                            fields = [{
+                                label: screen.label,
+                                key: screen.key,
                                 type: screen.type,
                                 dataType: 'diagnosis',
                                 optional: screen.skippable,
                                 confidential: screen.confidential,
-                            }));
+                                condition: screen.condition || '',
+                                options: screenOptions,
+                            }];
                             break;
 
                         case 'checklist':
-                            fields = items.map(item => ({
-                                value: item.id,
-                                valueLabel: item.label,
-                                label: item.label,
-                                key: item.key,
+                            fields = [{
+                                label: screen.label,
+                                key: screen.key,
                                 type: screen.type,
                                 dataType: null,
                                 optional: screen.skippable,
                                 confidential: screen.confidential,
-                            }));
+                                condition: screen.condition || '',
+                                options: screenOptions,
+                            }];
                             break;
 
                         case 'form':
@@ -433,20 +479,23 @@ export async function _getScriptsMetadata(params?: GetScriptsMetadataParams): Pr
                                         }));
                                     }
 
-                                    return opts.map(o => {
-                                        return {
-                                            label: f.label,
-                                            key: f.key,
-                                            type: f.type,
-                                            dataType,
-                                            value: o.value,
-                                            valueLabel: o.label,
-                                            optional: f.optional,
-                                            confidential: f.confidential,
-                                            disableOtherOptionsIfSelected: dataType === 'multi_select' ? !!o.disableOtherOptionsIfSelected : undefined,
-                                            forbidWith: dataType === 'multi_select' ? (o.forbidWith || []) : undefined,
-                                        };
-                                    });
+                                    const options = opts.map(o => ({
+                                        value: `${o.value || ''}`,
+                                        valueLabel: `${o.label || ''}`,
+                                        disabledOtherOptionsIfSelected: dataType === 'multi_select' ? !!o.disableOtherOptionsIfSelected : undefined,
+                                        forbidWIth: dataType === 'multi_select' ? (o.forbidWith || []) : undefined,
+                                    }));
+
+                                    return [{
+                                        label: f.label,
+                                        key: f.key,
+                                        type: f.type,
+                                        dataType,
+                                        optional: f.optional,
+                                        confidential: f.confidential,
+                                        condition: f.condition || '',
+                                        options,
+                                    }];
                                 }
 
                                 return [{
@@ -469,33 +518,29 @@ export async function _getScriptsMetadata(params?: GetScriptsMetadataParams): Pr
                             break;
 
                         case 'single_select':
-                            fields = items.map(item => ({
+                            fields = [{
                                 label: screen.label,
                                 key: screen.key,
                                 type: screen.type,
                                 dataType: 'single_select_option',
-                                value: item.id,
-                                valueLabel: item.label,
                                 optional: screen.skippable,
                                 confidential: screen.confidential,
-                            }));
+                                condition: screen.condition || '',
+                                options: screenOptions,
+                            }];
                             break;
 
                         case 'multi_select':
-                            fields = items.map(item => ({
+                            fields = [{
                                 label: screen.label,
                                 key: screen.key,
                                 type: screen.type,
                                 dataType: 'multi_select_option',
-                                value: item.id,
-                                valueLabel: item.label,
                                 optional: screen.skippable,
                                 confidential: screen.confidential,
-                                disableOtherOptionsIfSelected: !!item.exclusive,
-                                forbidWith: (item.forbidWith || [])
-                                    .map(forbidWithItemId => items.find(option => option.itemId === forbidWithItemId)?.id)
-                                    .filter((v): v is string => !!v),
-                            }));
+                                condition: screen.condition || '',
+                                options: screenOptions,
+                            }];
                             break;
                         default:
                         // do nothing
@@ -511,6 +556,7 @@ export async function _getScriptsMetadata(params?: GetScriptsMetadataParams): Pr
                         skipToScreen,
                         managementMetadata,
                         fields,
+                        items: screen.type === 'multi_select' ? undefined : screenItems,
                     };
                 }),
             });


### PR DESCRIPTION
## Summary
This PR refactors Scripts Metadata generation to make the payload cleaner and more consistent for downstream consumers (JSON + Excel export).

Main outcomes:
- Added richer metadata for fields/options/conditions where applicable.
- Removed duplicated field rows for option-based inputs.
- Standardized option-level keys and removed duplicate aliases.
- Moved conditions to field/screen level only.
- Removed `items` from metadata output (options now represent selectable items).
