### PR TITLE
Fix unsafe datakey ref fan-out and improve publish-time changelog traceability

### DIFF
--- a/app/(dashboard)/changelogs/[version]/changes/[changeId]/page.tsx
+++ b/app/(dashboard)/changelogs/[version]/changes/[changeId]/page.tsx
@@ -39,6 +39,7 @@ const entityTypeLabels: Record<string, string> = {
   script: "Script",
   screen: "Screen",
   diagnosis: "Diagnosis",
+  problem: "Problem",
   config_key: "Config Key",
   drugs_library: "Drugs Library",
   data_key: "Data Key",

--- a/app/(dashboard)/changelogs/[version]/page.tsx
+++ b/app/(dashboard)/changelogs/[version]/page.tsx
@@ -10,7 +10,9 @@ import { Badge } from "@/components/ui/badge"
 import { Separator } from "@/components/ui/separator"
 import { getChangeLogs } from "@/app/actions/change-logs"
 import { DataVersionChangesTable } from "../components/data-version-changes-table"
+import { DataVersionScriptGroups } from "../components/data-version-script-groups"
 import type { ChangeLogType } from "@/databases/queries/changelogs/_get-change-logs"
+import { buildDataVersionGroupedView } from "@/lib/changelog-data-version-groups"
 
 function normalizeChangeCount(changes: ChangeLogType["changes"]): number {
   if (Array.isArray(changes)) {
@@ -27,6 +29,7 @@ const entityTypeLabels: Record<string, string> = {
   script: "Script",
   screen: "Screen",
   diagnosis: "Diagnosis",
+  problem: "Problem",
   config_key: "Config Key",
   drugs_library: "Drugs Library",
   data_key: "Data Key",
@@ -131,6 +134,7 @@ export default async function DataVersionPage({ params }: { params: Params }) {
   }
 
   const entitySummary = formatEntitySummary(entityCounts)
+  const groupedView = buildDataVersionGroupedView(visibleChanges)
 
   return (
     <>
@@ -189,7 +193,28 @@ export default async function DataVersionPage({ params }: { params: Params }) {
 
             <Separator />
 
-            <DataVersionChangesTable changes={visibleChanges} dataVersion={numericVersion} />
+            <DataVersionScriptGroups groupedView={groupedView} dataVersion={numericVersion} />
+
+            <Separator />
+
+            <details className="rounded-lg border border-border/70 bg-muted/20">
+              <summary className="cursor-pointer list-none px-4 py-3">
+                <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <div className="text-sm font-semibold">Raw Timeline</div>
+                    <div className="text-xs text-muted-foreground">
+                      Full chronological changelog entries for audit-level inspection.
+                    </div>
+                  </div>
+                  <Badge variant="outline" className="w-fit bg-muted text-muted-foreground">
+                    {visibleChanges.length} entries
+                  </Badge>
+                </div>
+              </summary>
+              <div className="border-t border-border/60 p-4">
+                <DataVersionChangesTable changes={visibleChanges} dataVersion={numericVersion} />
+              </div>
+            </details>
           </CardContent>
         </Card>
       </Content>

--- a/app/(dashboard)/changelogs/components/data-version-changes-table.tsx
+++ b/app/(dashboard)/changelogs/components/data-version-changes-table.tsx
@@ -22,6 +22,7 @@ const entityTypeLabels: Record<string, string> = {
   script: "Script",
   screen: "Screen",
   diagnosis: "Diagnosis",
+  problem: "Problem",
   config_key: "Config Key",
   drugs_library: "Drugs Library",
   data_key: "Data Key",

--- a/app/(dashboard)/changelogs/components/data-version-script-groups.tsx
+++ b/app/(dashboard)/changelogs/components/data-version-script-groups.tsx
@@ -1,0 +1,230 @@
+import Link from "next/link"
+import { format } from "date-fns"
+import { ChevronRight } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import type {
+  DataVersionGroupedChange,
+  DataVersionGroupedView,
+  DataVersionScriptGroup,
+} from "@/lib/changelog-data-version-groups"
+
+type Props = {
+  groupedView: DataVersionGroupedView
+  dataVersion: number
+}
+
+const entityTypeLabels: Record<string, string> = {
+  script: "Script",
+  screen: "Screen",
+  diagnosis: "Diagnosis",
+  problem: "Problem",
+  config_key: "Config Key",
+  drugs_library: "Drugs Library",
+  data_key: "Data Key",
+  alias: "Alias",
+}
+
+const actionLabels: Record<string, string> = {
+  create: "Create",
+  update: "Update",
+  delete: "Delete",
+  publish: "Publish",
+  restore: "Restore",
+  rollback: "Rollback",
+  merge: "Merge",
+}
+
+const entityTypeOrder: DataVersionGroupedChange["entityType"][] = ["script", "screen", "diagnosis", "problem"]
+
+export function DataVersionScriptGroups({ groupedView, dataVersion }: Props) {
+  if (!groupedView.scriptGroups.length && !groupedView.standaloneChanges.length) {
+    return null
+  }
+
+  return (
+    <div className="space-y-4">
+      {groupedView.scriptGroups.length > 0 && (
+        <section className="space-y-3">
+          <div>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Affected Scripts</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Script-scoped changes are grouped here so screen, diagnosis, and problem updates stay traceable together.
+            </p>
+          </div>
+          <div className="space-y-3">
+            {groupedView.scriptGroups.map((group) => (
+              <ScriptGroupCard key={group.scriptId} group={group} dataVersion={dataVersion} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {groupedView.standaloneChanges.length > 0 && (
+        <section className="space-y-3">
+          <div>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Standalone Changes</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Changes that are not naturally scoped to a script remain listed separately.
+            </p>
+          </div>
+          <div className="rounded-lg border border-border/70 bg-background/70">
+            <div className="divide-y divide-border/60">
+              {groupedView.standaloneChanges.map((change) => (
+                <ChangeRow key={change.changeLogId} change={change} dataVersion={dataVersion} compact />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+    </div>
+  )
+}
+
+function ScriptGroupCard({ group, dataVersion }: { group: DataVersionScriptGroup; dataVersion: number }) {
+  const groupedChanges = new Map<string, DataVersionGroupedChange[]>()
+
+  for (const entityType of entityTypeOrder) {
+    groupedChanges.set(entityType, [])
+  }
+
+  for (const change of group.changes) {
+    const bucket = groupedChanges.get(change.entityType) || []
+    bucket.push(change)
+    groupedChanges.set(change.entityType, bucket)
+  }
+
+  return (
+    <details className="rounded-xl border border-border/70 bg-background/80 shadow-sm">
+      <summary className="cursor-pointer list-none px-4 py-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-2">
+            <div>
+              <div className="text-base font-semibold">{group.scriptTitle}</div>
+              <div className="text-xs text-muted-foreground">{group.scriptId}</div>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Badge variant="outline" className="bg-muted text-muted-foreground">
+                {group.totalChanges} changes
+              </Badge>
+              <Badge variant="outline" className="bg-muted text-muted-foreground">
+                {group.entitiesAffected} entities
+              </Badge>
+              <Badge variant="outline" className="bg-muted text-muted-foreground">
+                {group.fieldsChanged} fields updated
+              </Badge>
+              {group.screenChanges > 0 && (
+                <Badge variant="outline" className="bg-muted text-muted-foreground">
+                  {group.screenChanges} screens
+                </Badge>
+              )}
+              {group.diagnosisChanges > 0 && (
+                <Badge variant="outline" className="bg-muted text-muted-foreground">
+                  {group.diagnosisChanges} diagnoses
+                </Badge>
+              )}
+              {group.problemChanges > 0 && (
+                <Badge variant="outline" className="bg-muted text-muted-foreground">
+                  {group.problemChanges} problems
+                </Badge>
+              )}
+              {group.scriptChanges > 0 && (
+                <Badge variant="outline" className="bg-muted text-muted-foreground">
+                  {group.scriptChanges} script entries
+                </Badge>
+              )}
+            </div>
+          </div>
+          <div className="text-sm text-muted-foreground">
+            Latest change {format(new Date(group.latestChangeAt), "PPpp")}
+          </div>
+        </div>
+      </summary>
+      <div className="border-t border-border/60 px-4 py-4">
+        <div className="space-y-4">
+          {entityTypeOrder.map((entityType) => {
+            const changes = groupedChanges.get(entityType) || []
+            if (!changes.length) return null
+
+            return (
+              <section key={entityType} className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-sm font-semibold text-foreground">
+                    {entityTypeLabels[entityType] || entityType}
+                    {changes.length > 1 ? "s" : ""}
+                  </h3>
+                  <Badge variant="outline" className="bg-muted text-muted-foreground">
+                    {changes.length}
+                  </Badge>
+                </div>
+                <div className="overflow-hidden rounded-lg border border-border/60 bg-muted/20">
+                  {changes.map((change, index) => (
+                    <div key={change.changeLogId} className={index === 0 ? "" : "border-t border-border/50"}>
+                      <ChangeRow change={change} dataVersion={dataVersion} />
+                    </div>
+                  ))}
+                </div>
+              </section>
+            )
+          })}
+        </div>
+      </div>
+    </details>
+  )
+}
+
+function ChangeRow({
+  change,
+  dataVersion,
+  compact = false,
+}: {
+  change: DataVersionGroupedChange
+  dataVersion: number
+  compact?: boolean
+}) {
+  const entityLabel = entityTypeLabels[change.entityType] || change.entityType
+  const actionLabel = actionLabels[change.action] || change.action
+
+  return (
+    <div className="flex flex-col gap-3 px-4 py-3 md:flex-row md:items-start md:justify-between">
+      <div className="min-w-0 space-y-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-medium">{change.entityTitle}</span>
+          <Badge variant="outline" className="bg-muted text-muted-foreground">
+            {entityLabel}
+          </Badge>
+          <Badge variant="outline" className="bg-muted text-muted-foreground">
+            {actionLabel}
+          </Badge>
+          <Badge variant="outline" className="bg-muted text-muted-foreground">
+            {change.fieldsChanged} fields
+          </Badge>
+        </div>
+        <div className="text-xs text-muted-foreground">{change.entityId}</div>
+        {change.highlightedFields.length > 0 && (
+          <div className="text-xs text-muted-foreground">
+            Key fields: {change.highlightedFields.join(", ")}
+          </div>
+        )}
+        {!compact && change.changeReason && (
+          <div className="text-xs text-muted-foreground">
+            Reason: {change.changeReason}
+          </div>
+        )}
+        {!compact && change.description && (
+          <div className="text-xs text-muted-foreground line-clamp-2">{change.description}</div>
+        )}
+      </div>
+      <div className="flex items-center gap-3 md:flex-col md:items-end">
+        <div className="text-xs text-muted-foreground">{format(new Date(change.dateOfChange), "PPpp")}</div>
+        <Button asChild size="sm" variant="ghost" className="text-primary">
+          <Link href={`/changelogs/v${dataVersion}/changes/${change.changeLogId}`}>
+            View
+            <ChevronRight className="ml-1 h-4 w-4" />
+          </Link>
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/databases/mutations/changelogs/_save-change-log.ts
+++ b/databases/mutations/changelogs/_save-change-log.ts
@@ -71,7 +71,7 @@ const ENTITY_TYPE_TO_FK: Partial<Record<SaveChangeLogData["entityType"], keyof S
 const ENTITY_TYPE_ALLOWED_CONTEXT_FKS: Partial<Record<SaveChangeLogData["entityType"], (keyof SaveChangeLogData)[]>> = {
   screen: ["scriptId"],
   diagnosis: ["scriptId"],
-  problem: ["problemId"],
+  problem: ["scriptId"],
 }
 
 type EntityVersionConfig = {

--- a/databases/mutations/data-keys/_preview_refs.ts
+++ b/databases/mutations/data-keys/_preview_refs.ts
@@ -20,7 +20,6 @@ export async function _previewDataKeysRefsImpact({
             if (item.uniqueKey) existingMap[item.uniqueKey] = item;
         });
 
-        const previousDataKeys: NonNullable<Parameters<typeof _updateDataKeysRefs>[0]['previousDataKeys']> = [];
         const dataKeysToEvaluate: typeof byUuid.data = [];
 
         data.forEach(item => {
@@ -29,13 +28,6 @@ export async function _previewDataKeysRefsImpact({
                 (item.uniqueKey ? existingMap[item.uniqueKey] : undefined)
             );
             if (!existing?.uniqueKey) return;
-
-            previousDataKeys.push({
-                uniqueKey: existing.uniqueKey,
-                name: existing.name,
-                label: existing.label,
-                dataType: existing.dataType,
-            });
 
             dataKeysToEvaluate.push({
                 ...existing,
@@ -76,7 +68,6 @@ export async function _previewDataKeysRefsImpact({
 
         return await _updateDataKeysRefs({
             dataKeys: dataKeysToEvaluate,
-            previousDataKeys,
             dryRun: true,
         });
     } catch (e: any) {

--- a/databases/mutations/data-keys/_save.ts
+++ b/databases/mutations/data-keys/_save.ts
@@ -85,7 +85,6 @@ export async function _saveDataKeys({
         // }
 
         let index = 0;
-        const previousDataKeys: Array<{ uniqueKey: string; name?: string; label?: string; dataType?: string; }> = [];
         for (const { uuid: dataKeyUuid, isNewUuid, createdAt, publishDate, deletedAt, updatedAt, ...item } of data) {
             try {
                 item.name = `${item.name || ''}`.trim();
@@ -128,15 +127,6 @@ export async function _saveDataKeys({
                         });
                         data.confidential = resolvedConfidential;
 
-                        if (data.uniqueKey) {
-                            previousDataKeys.push({
-                                uniqueKey: data.uniqueKey,
-                                name: draft.data?.name,
-                                label: draft.data?.label,
-                                dataType: draft.data?.dataType || undefined,
-                            });
-                        }
-                        
                         await db
                             .update(dataKeysDrafts)
                             .set({
@@ -158,13 +148,6 @@ export async function _saveDataKeys({
                         } as typeof dataKeys.$inferSelect;
                         const resolvedConfidential = resolveConfidential({ incoming: item, existing: published });
                         data.confidential = resolvedConfidential;
-
-                        previousDataKeys.push({
-                            uniqueKey: data.uniqueKey,
-                            name: published?.name,
-                            label: published?.label,
-                            dataType: published?.dataType || undefined,
-                        });
 
                         await db.insert(dataKeysDrafts).values({
                             data,
@@ -188,7 +171,7 @@ export async function _saveDataKeys({
         } else {
             if (updateRefs && uniqueKeys.length) {
                 const { data: dataKeys, } = await _getDataKeys({ uniqueKeys, });
-                const updateRefsRes = await _updateDataKeysRefs({ dataKeys, previousDataKeys, broadcastAction, userId, });
+                const updateRefsRes = await _updateDataKeysRefs({ dataKeys, broadcastAction, userId, });
                 if (updateRefsRes.errors?.length || !updateRefsRes.success) {
                     response.success = false;
                     response.errors = updateRefsRes.errors?.length ? updateRefsRes.errors : ['Failed to update related scripts references'];

--- a/databases/mutations/data-keys/_update_data_keys_refs.ts
+++ b/databases/mutations/data-keys/_update_data_keys_refs.ts
@@ -7,22 +7,15 @@ import { diagnoses, diagnosesDrafts, problems, problemsDrafts, screens, screensD
 import { _getScreens, _getDiagnoses, _getProblems } from '@/databases/queries/scripts';
 import { _saveScreens, _saveDiagnoses, _saveProblems } from '@/databases/mutations/scripts';
 import { DataKey } from "@/databases/queries/data-keys";
-import { buildNormalizedDataKeyMatchKey } from '@/lib/data-key-types';
 
 export type UpdateDataKeysRefsParams = {
     broadcastAction?: boolean;
     dataKeys: DataKey[];
     dryRun?: boolean;
-    previousDataKeys?: Array<{
-        uniqueKey: string;
-        name?: string | null;
-        label?: string | null;
-        dataType?: string | null;
-    }>;
     userId?: string;
 };
 
-type MatchSource = 'uniqueKey' | 'legacyName' | 'legacyLabel';
+type MatchSource = 'uniqueKey';
 
 type UpdateStats = {
     candidateScripts: number;
@@ -88,7 +81,6 @@ const parsePositiveInt = (value: string | undefined, fallback: number) => {
 
 const SAVE_CHUNK_SIZE = parsePositiveInt(process.env.DATA_KEYS_REFS_SAVE_CHUNK_SIZE, 50);
 const SAVE_RETRY_CONCURRENCY = parsePositiveInt(process.env.DATA_KEYS_REFS_RETRY_CONCURRENCY, 5);
-const ALLOW_LEGACY_DATA_KEY_MATCH = process.env.DATA_KEYS_REFS_ALLOW_LEGACY_MATCH !== 'false';
 
 function chunkArray<T>(arr: T[], size: number): T[][] {
     if (size <= 0) return [arr];
@@ -104,10 +96,6 @@ function buildLikeClauses(column: SQL, patterns: string[]): SQL | undefined {
     const clauses = patterns.map(pattern => sql`${column}::text ILIKE ${pattern}`);
     if (clauses.length === 1) return clauses[0];
     return or(...clauses) as SQL;
-}
-
-function buildLegacyLookupKey(value: string, dataType?: string | null) {
-    return buildNormalizedDataKeyMatchKey(value, dataType);
 }
 
 function escapeLikePattern(value: string) {
@@ -136,7 +124,6 @@ async function mapWithConcurrency<T>(
 export async function _updateDataKeysRefs({
     dataKeys,
     dryRun = false,
-    previousDataKeys = [],
     broadcastAction,
     userId,
 }: UpdateDataKeysRefsParams): Promise<UpdateDataKeysRefsResponse> {
@@ -165,121 +152,15 @@ export async function _updateDataKeysRefs({
         });
 
         const changedUniqueKeys = Array.from(byUniqueKey.keys());
-        const legacyNameToUniqueKey = new Map<string, string>();
-        const legacyLabelToUniqueKey = new Map<string, string>();
-        const legacyNameFallbackToUniqueKey = new Map<string, string>();
-        const legacyLabelFallbackToUniqueKey = new Map<string, string>();
-        const legacyNameConflicts = new Set<string>();
-        const legacyLabelConflicts = new Set<string>();
-        const legacyNameFallbackConflicts = new Set<string>();
-        const legacyLabelFallbackConflicts = new Set<string>();
-        const oldNames = new Set<string>();
-        const oldLabels = new Set<string>();
-
-        previousDataKeys.forEach(prev => {
-            if (!prev.uniqueKey) return;
-            const current = byUniqueKey.get(prev.uniqueKey);
-            if (!current) return;
-
-            const oldName = `${prev.name || ''}`.trim();
-            const oldLabel = `${prev.label || ''}`.trim();
-
-            if (oldName && oldName !== current.name) {
-                oldNames.add(oldName);
-                const lookupKey = buildLegacyLookupKey(oldName, prev.dataType);
-                const existing = legacyNameToUniqueKey.get(lookupKey);
-                if (existing && existing !== current.uniqueKey) legacyNameConflicts.add(lookupKey);
-                legacyNameToUniqueKey.set(lookupKey, current.uniqueKey);
-
-                const fallbackLookupKey = buildLegacyLookupKey(oldName);
-                const fallbackExisting = legacyNameFallbackToUniqueKey.get(fallbackLookupKey);
-                if (fallbackExisting && fallbackExisting !== current.uniqueKey) legacyNameFallbackConflicts.add(fallbackLookupKey);
-                legacyNameFallbackToUniqueKey.set(fallbackLookupKey, current.uniqueKey);
-            }
-
-            if (oldLabel && oldLabel !== current.label) {
-                oldLabels.add(oldLabel);
-                const lookupKey = buildLegacyLookupKey(oldLabel, prev.dataType);
-                const existing = legacyLabelToUniqueKey.get(lookupKey);
-                if (existing && existing !== current.uniqueKey) legacyLabelConflicts.add(lookupKey);
-                legacyLabelToUniqueKey.set(lookupKey, current.uniqueKey);
-
-                const fallbackLookupKey = buildLegacyLookupKey(oldLabel);
-                const fallbackExisting = legacyLabelFallbackToUniqueKey.get(fallbackLookupKey);
-                if (fallbackExisting && fallbackExisting !== current.uniqueKey) legacyLabelFallbackConflicts.add(fallbackLookupKey);
-                legacyLabelFallbackToUniqueKey.set(fallbackLookupKey, current.uniqueKey);
-            }
-        });
 
         const getUpdatedDataKey = ({
             uniqueKey,
-            key,
-            label,
-            dataType,
         }: {
             uniqueKey?: string | null;
-            key?: string | null;
-            label?: string | null;
-            dataType?: string | null;
         }): { dataKey?: DataKey; source?: MatchSource } => {
             if (uniqueKey) {
                 const keyById = byUniqueKey.get(uniqueKey);
                 if (keyById) return { dataKey: keyById, source: 'uniqueKey' };
-            }
-
-            if (!ALLOW_LEGACY_DATA_KEY_MATCH) {
-                return {};
-            }
-
-            const trimmedKey = `${key || ''}`.trim();
-            const trimmedLabel = `${label || ''}`.trim();
-
-            if (trimmedKey) {
-                const legacyLookupKey = buildLegacyLookupKey(trimmedKey, dataType);
-                if (legacyNameConflicts.has(legacyLookupKey)) {
-                    stats.ambiguousLegacySkips++;
-                } else {
-                    const matchedUniqueKey = legacyNameToUniqueKey.get(legacyLookupKey);
-                    if (matchedUniqueKey) {
-                        const matched = byUniqueKey.get(matchedUniqueKey);
-                        if (matched) return { dataKey: matched, source: 'legacyName' };
-                    }
-                }
-
-                const fallbackLookupKey = buildLegacyLookupKey(trimmedKey);
-                if (legacyNameFallbackConflicts.has(fallbackLookupKey)) {
-                    stats.ambiguousLegacySkips++;
-                } else {
-                    const matchedUniqueKey = legacyNameFallbackToUniqueKey.get(fallbackLookupKey);
-                    if (matchedUniqueKey) {
-                        const matched = byUniqueKey.get(matchedUniqueKey);
-                        if (matched) return { dataKey: matched, source: 'legacyName' };
-                    }
-                }
-            }
-
-            if (trimmedLabel) {
-                const legacyLookupKey = buildLegacyLookupKey(trimmedLabel, dataType);
-                if (legacyLabelConflicts.has(legacyLookupKey)) {
-                    stats.ambiguousLegacySkips++;
-                } else {
-                    const matchedUniqueKey = legacyLabelToUniqueKey.get(legacyLookupKey);
-                    if (matchedUniqueKey) {
-                        const matched = byUniqueKey.get(matchedUniqueKey);
-                        if (matched) return { dataKey: matched, source: 'legacyLabel' };
-                    }
-                }
-
-                const fallbackLookupKey = buildLegacyLookupKey(trimmedLabel);
-                if (legacyLabelFallbackConflicts.has(fallbackLookupKey)) {
-                    stats.ambiguousLegacySkips++;
-                } else {
-                    const matchedUniqueKey = legacyLabelFallbackToUniqueKey.get(fallbackLookupKey);
-                    if (matchedUniqueKey) {
-                        const matched = byUniqueKey.get(matchedUniqueKey);
-                        if (matched) return { dataKey: matched, source: 'legacyLabel' };
-                    }
-                }
             }
 
             return {};
@@ -287,8 +168,6 @@ export async function _updateDataKeysRefs({
 
         const trackMatchSource = (source?: MatchSource) => {
             if (source === 'uniqueKey') stats.matchedByUniqueKey++;
-            if (source === 'legacyName') stats.matchedByLegacyName++;
-            if (source === 'legacyLabel') stats.matchedByLegacyLabel++;
         };
         const getDataKeyOptional = (key?: DataKey) => !!(key?.metadata as Record<string, any> | undefined)?.optional;
 
@@ -305,9 +184,6 @@ export async function _updateDataKeysRefs({
             usagesMap.set(dedupeKey, usage);
         };
 
-        const oldNamesArr = Array.from(oldNames);
-        const oldLabelsArr = Array.from(oldLabels);
-
         const keyIdPatterns = changedUniqueKeys
             .filter(Boolean)
             .slice(0, 120)
@@ -319,49 +195,13 @@ export async function _updateDataKeysRefs({
                     `%\"keyId\"%\"${id}\"%`,
                 ];
             });
-        const oldNamePatterns = oldNamesArr
-            .filter(Boolean)
-            .slice(0, 80)
-            .flatMap(name => {
-                const n = escapeLikePattern(name);
-                return [
-                    `%\"key\":\"${n}\"%`,
-                    `%\"key\": \"${n}\"%`,
-                    `%\"key\"%\"${n}\"%`,
-                    `%\"id\":\"${n}\"%`,
-                    `%\"id\": \"${n}\"%`,
-                    `%\"id\"%\"${n}\"%`,
-                    `%\"value\":\"${n}\"%`,
-                    `%\"value\": \"${n}\"%`,
-                    `%\"value\"%\"${n}\"%`,
-                    `%\"refKey\":\"${n}\"%`,
-                    `%\"refKey\": \"${n}\"%`,
-                    `%\"refKey\"%\"${n}\"%`,
-                ];
-            });
-        const oldLabelPatterns = oldLabelsArr
-            .filter(Boolean)
-            .slice(0, 80)
-            .flatMap(label => {
-                const l = escapeLikePattern(label);
-                return [
-                    `%\"label\":\"${l}\"%`,
-                    `%\"label\": \"${l}\"%`,
-                    `%\"label\"%\"${l}\"%`,
-                    `%\"name\":\"${l}\"%`,
-                    `%\"name\": \"${l}\"%`,
-                    `%\"name\"%\"${l}\"%`,
-                ];
-            });
         const likePatterns = Array.from(new Set([
             ...keyIdPatterns,
-            ...oldNamePatterns,
-            ...oldLabelPatterns,
         ])).slice(0, 240);
 
         const candidateScripts = new Set<string>();
 
-        if (changedUniqueKeys.length || oldNames.size || oldLabels.size || likePatterns.length) {
+        if (changedUniqueKeys.length || likePatterns.length) {
             const screensPublishedCandidates = await db
                 .select({ scriptId: screens.scriptId })
                 .from(screens)
@@ -370,9 +210,6 @@ export async function _updateDataKeysRefs({
                     or(
                         changedUniqueKeys.length ? inArray(screens.keyId, changedUniqueKeys) : undefined,
                         changedUniqueKeys.length ? inArray(screens.refIdDataKey, changedUniqueKeys) : undefined,
-                        oldNamesArr.length ? inArray(screens.key, oldNamesArr) : undefined,
-                        oldLabelsArr.length ? inArray(screens.label, oldLabelsArr) : undefined,
-                        oldNamesArr.length ? inArray(screens.refId, oldNamesArr) : undefined,
                         buildLikeClauses(sql`${screens.fields}`, likePatterns),
                         buildLikeClauses(sql`${screens.items}`, likePatterns),
                     ),
@@ -389,8 +226,6 @@ export async function _updateDataKeysRefs({
                     isNull(diagnoses.deletedAt),
                     or(
                         changedUniqueKeys.length ? inArray(diagnoses.keyId, changedUniqueKeys) : undefined,
-                        oldNamesArr.length ? inArray(diagnoses.key, oldNamesArr) : undefined,
-                        oldLabelsArr.length ? inArray(diagnoses.name, oldLabelsArr) : undefined,
                         buildLikeClauses(sql`${diagnoses.symptoms}`, likePatterns),
                     ),
                 ));
@@ -406,8 +241,6 @@ export async function _updateDataKeysRefs({
                     isNull(problems.deletedAt),
                     or(
                         changedUniqueKeys.length ? inArray(problems.keyId, changedUniqueKeys) : undefined,
-                        oldNamesArr.length ? inArray(problems.key, oldNamesArr) : undefined,
-                        oldLabelsArr.length ? inArray(problems.name, oldLabelsArr) : undefined,
                     ),
                 ));
 
@@ -459,11 +292,7 @@ export async function _updateDataKeysRefs({
 
         stats.candidateScripts = candidateScripts.size;
 
-        const shouldFallbackToFullScan = !candidateScripts.size && (
-            changedUniqueKeys.length > 0 ||
-            oldNamesArr.length > 0 ||
-            oldLabelsArr.length > 0
-        );
+        const shouldFallbackToFullScan = !candidateScripts.size && changedUniqueKeys.length > 0;
 
         const useFullScan = dryRun || shouldFallbackToFullScan;
 
@@ -508,15 +337,11 @@ export async function _updateDataKeysRefs({
         let screensUpdatedData: typeof screensArr = screensArr.map(s => {
             const { dataKey: refIdDataKey, source: refMatchSource } = getUpdatedDataKey({
                 uniqueKey: s.refIdDataKey || s.refId,
-                key: s.refId,
             });
             trackMatchSource(refMatchSource);
 
             const { dataKey: screenDataKey, source: screenMatchSource } = getUpdatedDataKey({
                 uniqueKey: s.keyId,
-                key: s.key,
-                label: s.label,
-                dataType: s.type || undefined,
             });
             trackMatchSource(screenMatchSource);
 
@@ -537,9 +362,6 @@ export async function _updateDataKeysRefs({
             const items = (s.items || []).map((item, itemIndex) => {
                 const { dataKey: itemDataKey, source: itemMatchSource } = getUpdatedDataKey({
                     uniqueKey: item.keyId,
-                    key: item.key || item.id,
-                    label: item.label,
-                    dataType: s.type === 'diagnosis' ? 'diagnosis' : 'option',
                 });
                 trackMatchSource(itemMatchSource);
 
@@ -571,39 +393,31 @@ export async function _updateDataKeysRefs({
             const fields = (s.fields || []).map((field, fieldIndex) => {
                 const { dataKey: fieldDataKey, source: fieldMatchSource } = getUpdatedDataKey({
                     uniqueKey: field.keyId,
-                    key: field.key,
-                    label: field.label,
-                    dataType: field.type || undefined,
                 });
                 trackMatchSource(fieldMatchSource);
 
                 const { dataKey: refKeyDataKey, source: refKeyMatchSource } = getUpdatedDataKey({
                     uniqueKey: field.refKeyId,
-                    key: field.refKey,
                 });
                 trackMatchSource(refKeyMatchSource);
 
                 const { dataKey: minDateKeyDataKey, source: minDateMatchSource } = getUpdatedDataKey({
                     uniqueKey: field.minDateKeyId,
-                    key: field.minDateKey,
                 });
                 trackMatchSource(minDateMatchSource);
 
                 const { dataKey: maxDateKeyDataKey, source: maxDateMatchSource } = getUpdatedDataKey({
                     uniqueKey: field.maxDateKeyId,
-                    key: field.maxDateKey,
                 });
                 trackMatchSource(maxDateMatchSource);
 
                 const { dataKey: minTimeKeyDataKey, source: minTimeMatchSource } = getUpdatedDataKey({
                     uniqueKey: field.minTimeKeyId,
-                    key: field.minTimeKey,
                 });
                 trackMatchSource(minTimeMatchSource);
 
                 const { dataKey: maxTimeKeyDataKey, source: maxTimeMatchSource } = getUpdatedDataKey({
                     uniqueKey: field.maxTimeKeyId,
-                    key: field.maxTimeKey,
                 });
                 trackMatchSource(maxTimeMatchSource);
 
@@ -656,9 +470,6 @@ export async function _updateDataKeysRefs({
                     items: (field.items || []).map((item, fieldItemIndex) => {
                         const { dataKey: fieldItemDataKey, source: fieldItemMatchSource } = getUpdatedDataKey({
                             uniqueKey: item.keyId,
-                            key: `${item.value || ''}`,
-                            label: `${item.label || ''}`,
-                            dataType: 'option',
                         });
                         trackMatchSource(fieldItemMatchSource);
 
@@ -710,9 +521,6 @@ export async function _updateDataKeysRefs({
             const name = d.key || d.name || '';
             const { dataKey: diagnosisDataKey, source: diagnosisMatchSource } = getUpdatedDataKey({
                 uniqueKey: d.keyId,
-                key: d.key,
-                label: d.name,
-                dataType: 'diagnosis',
             });
             trackMatchSource(diagnosisMatchSource);
 
@@ -733,9 +541,6 @@ export async function _updateDataKeysRefs({
             const symptoms = (d.symptoms || []).map((item, symptomIndex) => {
                 const { dataKey: symptomDataKey, source: symptomMatchSource } = getUpdatedDataKey({
                     uniqueKey: item.keyId,
-                    key: item.key,
-                    label: item.name,
-                    dataType: `diagnosis_symptom_${item.type}`,
                 });
                 trackMatchSource(symptomMatchSource);
 
@@ -779,9 +584,6 @@ export async function _updateDataKeysRefs({
             const name = d.key || d.name || '';
             const { dataKey: problemDataKey, source: problemMatchSource } = getUpdatedDataKey({
                 uniqueKey: d.keyId,
-                key: d.key,
-                label: d.name,
-                dataType: 'problem',
             });
             trackMatchSource(problemMatchSource);
 
@@ -837,7 +639,7 @@ export async function _updateDataKeysRefs({
             type: 'problem',
         }));
         const affectedScriptsMap: { [key: string]: { scriptId: string; scriptTitle?: string; }; } = {};
-        [...affectedScreens, ...affectedDiagnoses].forEach(entity => {
+        [...affectedScreens, ...affectedDiagnoses, ...affectedProblems].forEach(entity => {
             if (!entity.scriptId) return;
             if (!affectedScriptsMap[entity.scriptId]) {
                 affectedScriptsMap[entity.scriptId] = {
@@ -889,7 +691,7 @@ export async function _updateDataKeysRefs({
                 if (res.errors?.length) {
                     stats.chunkRetries++;
                     await mapWithConcurrency(chunk, SAVE_RETRY_CONCURRENCY, async (problem) => {
-                        const singleRes = await _saveDiagnoses({ data: [problem], userId, });
+                        const singleRes = await _saveProblems({ data: [problem], userId, });
                         if (singleRes.errors?.length) {
                             saveErrors.push(...singleRes.errors.map(e => `[problem:${problem.problemId}] ${e}`));
                         } else {

--- a/databases/mutations/scripts/_diagnoses_history.ts
+++ b/databases/mutations/scripts/_diagnoses_history.ts
@@ -3,6 +3,7 @@ import db from "@/databases/pg/drizzle"
 import logger from "@/lib/logger"
 import { diagnosesDrafts, diagnoses, diagnosesHistory } from "@/databases/pg/schema"
 import { removeHexCharacters } from "../../utils"
+import { getDataKeySyncChangeReason } from "@/lib/changelog-data-key-sync"
 
 export async function _saveDiagnosesHistory({
   previous,
@@ -64,6 +65,7 @@ export async function _saveDiagnosesHistory({
         const previousSnapshot = isCreate
           ? {}
           : removeHexCharacters(previous.find((prevC) => prevC.diagnosisId === diagnosisId) || {})
+        const changeReason = isCreate ? undefined : getDataKeySyncChangeReason(previousSnapshot, sanitizedSnapshot)
 
         changeLogsData.push({
           entityId: diagnosisId,
@@ -75,6 +77,7 @@ export async function _saveDiagnosesHistory({
           previousSnapshot,
           baselineSnapshot: previousSnapshot,
           description: changeDescription,
+          changeReason,
           userId,
           scriptId: c?.data?.scriptId || null,
           diagnosisId,

--- a/databases/mutations/scripts/_problems_history.ts
+++ b/databases/mutations/scripts/_problems_history.ts
@@ -3,6 +3,7 @@ import db from "@/databases/pg/drizzle"
 import logger from "@/lib/logger"
 import { problemsDrafts, problems, problemsHistory } from "@/databases/pg/schema"
 import { removeHexCharacters } from "../../utils"
+import { getDataKeySyncChangeReason } from "@/lib/changelog-data-key-sync"
 
 export async function _saveProblemsHistory({
   previous,
@@ -64,6 +65,7 @@ export async function _saveProblemsHistory({
         const previousSnapshot = isCreate
           ? {}
           : removeHexCharacters(previous.find((prevC) => prevC.problemId === problemId) || {})
+        const changeReason = isCreate ? undefined : getDataKeySyncChangeReason(previousSnapshot, sanitizedSnapshot)
 
         changeLogsData.push({
           entityId: problemId,
@@ -75,6 +77,7 @@ export async function _saveProblemsHistory({
           previousSnapshot,
           baselineSnapshot: previousSnapshot,
           description: changeDescription,
+          changeReason,
           userId,
           scriptId: c?.data?.scriptId || null,
           problemId,

--- a/databases/mutations/scripts/_screens_history.ts
+++ b/databases/mutations/scripts/_screens_history.ts
@@ -3,6 +3,7 @@ import db from "@/databases/pg/drizzle"
 import logger from "@/lib/logger"
 import { screensDrafts, screens, screensHistory } from "@/databases/pg/schema"
 import { removeHexCharacters } from "../../utils"
+import { getDataKeySyncChangeReason } from "@/lib/changelog-data-key-sync"
 
 export async function _saveScreensHistory({
   previous,
@@ -72,6 +73,7 @@ export async function _saveScreensHistory({
         const previousSnapshot = isCreate
           ? {}
           : removeHexCharacters(previous.find((prevC) => prevC.screenId === screenId) || {})
+        const changeReason = isCreate ? undefined : getDataKeySyncChangeReason(previousSnapshot, sanitizedSnapshot)
 
         changeLogsData.push({
           entityId: screenId,
@@ -82,6 +84,7 @@ export async function _saveScreensHistory({
           fullSnapshot: sanitizedSnapshot,
           previousSnapshot,
           baselineSnapshot: previousSnapshot,
+          changeReason,
           userId,
           scriptId: c?.data?.scriptId || null,
           screenId,

--- a/databases/mutations/scripts/_scripts_history.ts
+++ b/databases/mutations/scripts/_scripts_history.ts
@@ -3,6 +3,7 @@ import db from "@/databases/pg/drizzle"
 import { scriptsDrafts, scripts, scriptsHistory } from "@/databases/pg/schema"
 import logger from "@/lib/logger"
 import { removeHexCharacters } from "../../utils"
+import { getDataKeySyncChangeReason } from "@/lib/changelog-data-key-sync"
 
 export async function _saveScriptsHistory({
   previous,
@@ -71,6 +72,7 @@ export async function _saveScriptsHistory({
         const previousSnapshot = isCreate
           ? {}
           : removeHexCharacters(previous.find((prevC) => prevC.scriptId === scriptId) || {})
+        const changeReason = isCreate ? undefined : getDataKeySyncChangeReason(previousSnapshot, sanitizedSnapshot)
 
         changeLogsData.push({
           entityId: scriptId,
@@ -81,6 +83,7 @@ export async function _saveScriptsHistory({
           fullSnapshot: sanitizedSnapshot,
           previousSnapshot,
           baselineSnapshot: previousSnapshot,
+          changeReason,
           userId,
           scriptId,
         })

--- a/databases/pg/migrations/0011_tearful_angel.sql
+++ b/databases/pg/migrations/0011_tearful_angel.sql
@@ -1,0 +1,129 @@
+ALTER TYPE "change_log_entity" ADD VALUE 'problem';--> statement-breakpoint
+ALTER TYPE "screen_type" ADD VALUE 'problems';--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "nt_problems" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"problem_id" uuid DEFAULT gen_random_uuid() NOT NULL,
+	"old_script_id" text,
+	"version" integer NOT NULL,
+	"script_id" uuid NOT NULL,
+	"position" integer NOT NULL,
+	"source" text DEFAULT 'editor',
+	"expression" text NOT NULL,
+	"name" text DEFAULT '' NOT NULL,
+	"description" text DEFAULT '' NOT NULL,
+	"key" text DEFAULT '',
+	"key_id" text DEFAULT '' NOT NULL,
+	"severity_order" integer,
+	"expression_meaning" text DEFAULT '' NOT NULL,
+	"text1" text DEFAULT '' NOT NULL,
+	"text2" text DEFAULT '' NOT NULL,
+	"text3" text DEFAULT '' NOT NULL,
+	"image1" jsonb,
+	"image2" jsonb,
+	"image3" jsonb,
+	"preferences" jsonb DEFAULT '{"fontSize":{},"fontWeight":{},"fontStyle":{},"textColor":{},"backgroundColor":{},"highlight":{}}' NOT NULL,
+	"publish_date" timestamp DEFAULT now() NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"deleted_at" timestamp,
+	CONSTRAINT "nt_problems_problem_id_unique" UNIQUE("problem_id")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "nt_problems_drafts" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"problem_draft_id" uuid DEFAULT gen_random_uuid() NOT NULL,
+	"problem_id" uuid,
+	"script_id" uuid,
+	"script_draft_id" uuid,
+	"position" integer NOT NULL,
+	"data" jsonb NOT NULL,
+	"created_by_user_id" uuid,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "nt_problems_drafts_problem_draft_id_unique" UNIQUE("problem_draft_id")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "nt_problems_history" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"version" integer NOT NULL,
+	"problem_id" uuid NOT NULL,
+	"script_id" uuid NOT NULL,
+	"restore_key" text,
+	"data" jsonb DEFAULT '[]'::jsonb,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "nt_change_logs" ADD COLUMN "problem_id" uuid;--> statement-breakpoint
+ALTER TABLE "nt_pending_deletion" ADD COLUMN "problem_id" uuid;--> statement-breakpoint
+ALTER TABLE "nt_pending_deletion" ADD COLUMN "problem_script_id" uuid;--> statement-breakpoint
+ALTER TABLE "nt_pending_deletion" ADD COLUMN "problem_draft_id" uuid;--> statement-breakpoint
+ALTER TABLE "nt_screens" ADD COLUMN "hcw_problems_instructions" text DEFAULT '' NOT NULL;--> statement-breakpoint
+ALTER TABLE "nt_screens" ADD COLUMN "suggested_problems_instructions" text DEFAULT '' NOT NULL;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "nt_problems" ADD CONSTRAINT "nt_problems_script_id_nt_scripts_script_id_fk" FOREIGN KEY ("script_id") REFERENCES "public"."nt_scripts"("script_id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "nt_problems_drafts" ADD CONSTRAINT "nt_problems_drafts_problem_id_nt_problems_problem_id_fk" FOREIGN KEY ("problem_id") REFERENCES "public"."nt_problems"("problem_id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "nt_problems_drafts" ADD CONSTRAINT "nt_problems_drafts_script_id_nt_scripts_script_id_fk" FOREIGN KEY ("script_id") REFERENCES "public"."nt_scripts"("script_id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "nt_problems_drafts" ADD CONSTRAINT "nt_problems_drafts_script_draft_id_nt_scripts_drafts_script_draft_id_fk" FOREIGN KEY ("script_draft_id") REFERENCES "public"."nt_scripts_drafts"("script_draft_id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "nt_problems_drafts" ADD CONSTRAINT "nt_problems_drafts_created_by_user_id_nt_users_user_id_fk" FOREIGN KEY ("created_by_user_id") REFERENCES "public"."nt_users"("user_id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "nt_problems_history" ADD CONSTRAINT "nt_problems_history_problem_id_nt_problems_problem_id_fk" FOREIGN KEY ("problem_id") REFERENCES "public"."nt_problems"("problem_id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "nt_problems_history" ADD CONSTRAINT "nt_problems_history_script_id_nt_scripts_script_id_fk" FOREIGN KEY ("script_id") REFERENCES "public"."nt_scripts"("script_id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "problems_search_index" ON "nt_problems" USING gin ((
+                    to_tsvector('english', "name")
+                ));--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "nt_change_logs" ADD CONSTRAINT "nt_change_logs_problem_id_nt_problems_problem_id_fk" FOREIGN KEY ("problem_id") REFERENCES "public"."nt_problems"("problem_id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "nt_pending_deletion" ADD CONSTRAINT "nt_pending_deletion_problem_id_nt_problems_problem_id_fk" FOREIGN KEY ("problem_id") REFERENCES "public"."nt_problems"("problem_id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "nt_pending_deletion" ADD CONSTRAINT "nt_pending_deletion_problem_script_id_nt_scripts_script_id_fk" FOREIGN KEY ("problem_script_id") REFERENCES "public"."nt_scripts"("script_id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "nt_pending_deletion" ADD CONSTRAINT "nt_pending_deletion_problem_draft_id_nt_problems_drafts_problem_draft_id_fk" FOREIGN KEY ("problem_draft_id") REFERENCES "public"."nt_problems_drafts"("problem_draft_id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/databases/pg/migrations/meta/0011_snapshot.json
+++ b/databases/pg/migrations/meta/0011_snapshot.json
@@ -1,0 +1,5634 @@
+{
+  "id": "b2e4d52f-77d7-4ce6-ae8a-09d9e8ff190b",
+  "prevId": "6472c5cc-6be3-4c40-9610-4b6165541056",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.nt_api_keys": {
+      "name": "nt_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_api_keys_api_key_id_unique": {
+          "name": "nt_api_keys_api_key_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "api_key_id"
+          ]
+        },
+        "nt_api_keys_api_key_unique": {
+          "name": "nt_api_keys_api_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "api_key"
+          ]
+        }
+      }
+    },
+    "public.nt_auth_clients": {
+      "name": "nt_auth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "client_token": {
+          "name": "client_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_auth_clients_user_id_nt_users_user_id_fk": {
+          "name": "nt_auth_clients_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_auth_clients",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_auth_clients_client_id_unique": {
+          "name": "nt_auth_clients_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        },
+        "nt_auth_clients_client_token_unique": {
+          "name": "nt_auth_clients_client_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_token"
+          ]
+        }
+      }
+    },
+    "public.nt_change_logs": {
+      "name": "nt_change_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "change_log_id": {
+          "name": "change_log_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "change_log_entity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_version": {
+          "name": "parent_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_from_version": {
+          "name": "merged_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_id": {
+          "name": "screen_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosis_id": {
+          "name": "diagnosis_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_key_id": {
+          "name": "config_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hospital_id": {
+          "name": "hospital_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drugs_library_item_id": {
+          "name": "drugs_library_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_key_id": {
+          "name": "data_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "change_log_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "full_snapshot": {
+          "name": "full_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_snapshot": {
+          "name": "previous_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "snapshot_hash": {
+          "name": "snapshot_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "change_reason": {
+          "name": "change_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_change": {
+          "name": "date_of_change",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "data_version": {
+          "name": "data_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "unique_version_per_entity": {
+          "name": "unique_version_per_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "active_version_index": {
+          "name": "active_version_index",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_logs_entity_index": {
+          "name": "change_logs_entity_index",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "version_chain_index": {
+          "name": "version_chain_index",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_logs_user_index": {
+          "name": "change_logs_user_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_logs_date_index": {
+          "name": "change_logs_date_index",
+          "columns": [
+            {
+              "expression": "date_of_change",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_logs_data_version_index": {
+          "name": "change_logs_data_version_index",
+          "columns": [
+            {
+              "expression": "data_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nt_change_logs_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_change_logs_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_change_logs",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "nt_change_logs_screen_id_nt_screens_screen_id_fk": {
+          "name": "nt_change_logs_screen_id_nt_screens_screen_id_fk",
+          "tableFrom": "nt_change_logs",
+          "tableTo": "nt_screens",
+          "columnsFrom": [
+            "screen_id"
+          ],
+          "columnsTo": [
+            "screen_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "nt_change_logs_diagnosis_id_nt_diagnoses_diagnosis_id_fk": {
+          "name": "nt_change_logs_diagnosis_id_nt_diagnoses_diagnosis_id_fk",
+          "tableFrom": "nt_change_logs",
+          "tableTo": "nt_diagnoses",
+          "columnsFrom": [
+            "diagnosis_id"
+          ],
+          "columnsTo": [
+            "diagnosis_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "nt_change_logs_problem_id_nt_problems_problem_id_fk": {
+          "name": "nt_change_logs_problem_id_nt_problems_problem_id_fk",
+          "tableFrom": "nt_change_logs",
+          "tableTo": "nt_problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "problem_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "nt_change_logs_config_key_id_nt_config_keys_config_key_id_fk": {
+          "name": "nt_change_logs_config_key_id_nt_config_keys_config_key_id_fk",
+          "tableFrom": "nt_change_logs",
+          "tableTo": "nt_config_keys",
+          "columnsFrom": [
+            "config_key_id"
+          ],
+          "columnsTo": [
+            "config_key_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "nt_change_logs_hospital_id_nt_hospitals_hospital_id_fk": {
+          "name": "nt_change_logs_hospital_id_nt_hospitals_hospital_id_fk",
+          "tableFrom": "nt_change_logs",
+          "tableTo": "nt_hospitals",
+          "columnsFrom": [
+            "hospital_id"
+          ],
+          "columnsTo": [
+            "hospital_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "nt_change_logs_drugs_library_item_id_nt_drugs_library_item_id_fk": {
+          "name": "nt_change_logs_drugs_library_item_id_nt_drugs_library_item_id_fk",
+          "tableFrom": "nt_change_logs",
+          "tableTo": "nt_drugs_library",
+          "columnsFrom": [
+            "drugs_library_item_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "nt_change_logs_data_key_id_nt_data_keys_uuid_fk": {
+          "name": "nt_change_logs_data_key_id_nt_data_keys_uuid_fk",
+          "tableFrom": "nt_change_logs",
+          "tableTo": "nt_data_keys",
+          "columnsFrom": [
+            "data_key_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "nt_change_logs_alias_id_nt_aliases_uuid_fk": {
+          "name": "nt_change_logs_alias_id_nt_aliases_uuid_fk",
+          "tableFrom": "nt_change_logs",
+          "tableTo": "nt_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "nt_change_logs_user_id_nt_users_user_id_fk": {
+          "name": "nt_change_logs_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_change_logs",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_change_logs_change_log_id_unique": {
+          "name": "nt_change_logs_change_log_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "change_log_id"
+          ]
+        }
+      }
+    },
+    "public.nt_config_keys": {
+      "name": "nt_config_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_key_id": {
+          "name": "config_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "old_config_key_id": {
+          "name": "old_config_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'editor'"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"fontSize\":{},\"fontWeight\":{},\"fontStyle\":{},\"textColor\":{},\"backgroundColor\":{},\"highlight\":{}}'"
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "config_keys_search_index": {
+          "name": "config_keys_search_index",
+          "columns": [
+            {
+              "expression": "(\n                    to_tsvector('english', \"key\") ||\n                    to_tsvector('english', \"label\") ||\n                    to_tsvector('english', \"summary\")\n                )",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_config_keys_config_key_id_unique": {
+          "name": "nt_config_keys_config_key_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "config_key_id"
+          ]
+        },
+        "nt_config_keys_old_config_key_id_unique": {
+          "name": "nt_config_keys_old_config_key_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "old_config_key_id"
+          ]
+        },
+        "nt_config_keys_key_unique": {
+          "name": "nt_config_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        },
+        "nt_config_keys_label_unique": {
+          "name": "nt_config_keys_label_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label"
+          ]
+        }
+      }
+    },
+    "public.nt_config_keys_drafts": {
+      "name": "nt_config_keys_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_key_draft_id": {
+          "name": "config_key_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "config_key_id": {
+          "name": "config_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_config_keys_drafts_config_key_id_nt_config_keys_config_key_id_fk": {
+          "name": "nt_config_keys_drafts_config_key_id_nt_config_keys_config_key_id_fk",
+          "tableFrom": "nt_config_keys_drafts",
+          "tableTo": "nt_config_keys",
+          "columnsFrom": [
+            "config_key_id"
+          ],
+          "columnsTo": [
+            "config_key_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_config_keys_drafts_created_by_user_id_nt_users_user_id_fk": {
+          "name": "nt_config_keys_drafts_created_by_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_config_keys_drafts",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_config_keys_drafts_config_key_draft_id_unique": {
+          "name": "nt_config_keys_drafts_config_key_draft_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "config_key_draft_id"
+          ]
+        }
+      }
+    },
+    "public.nt_config_keys_history": {
+      "name": "nt_config_keys_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_key_id": {
+          "name": "config_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restore_key": {
+          "name": "restore_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_config_keys_history_config_key_id_nt_config_keys_config_key_id_fk": {
+          "name": "nt_config_keys_history_config_key_id_nt_config_keys_config_key_id_fk",
+          "tableFrom": "nt_config_keys_history",
+          "tableTo": "nt_config_keys",
+          "columnsFrom": [
+            "config_key_id"
+          ],
+          "columnsTo": [
+            "config_key_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nt_devices": {
+      "name": "nt_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_hash": {
+          "name": "device_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_devices_device_id_unique": {
+          "name": "nt_devices_device_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_id"
+          ]
+        },
+        "nt_devices_device_hash_unique": {
+          "name": "nt_devices_device_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_hash"
+          ]
+        }
+      }
+    },
+    "public.nt_diagnoses": {
+      "name": "nt_diagnoses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "diagnosis_id": {
+          "name": "diagnosis_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "old_diagnosis_id": {
+          "name": "old_diagnosis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_script_id": {
+          "name": "old_script_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'editor'"
+        },
+        "expression": {
+          "name": "expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "severity_order": {
+          "name": "severity_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expression_meaning": {
+          "name": "expression_meaning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "symptoms": {
+          "name": "symptoms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "text1": {
+          "name": "text1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "text2": {
+          "name": "text2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "text3": {
+          "name": "text3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "image1": {
+          "name": "image1",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image2": {
+          "name": "image2",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image3": {
+          "name": "image3",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"fontSize\":{},\"fontWeight\":{},\"fontStyle\":{},\"textColor\":{},\"backgroundColor\":{},\"highlight\":{}}'"
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "diagnoses_search_index": {
+          "name": "diagnoses_search_index",
+          "columns": [
+            {
+              "expression": "(\n                    to_tsvector('english', \"name\")\n                )",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nt_diagnoses_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_diagnoses_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_diagnoses",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_diagnoses_diagnosis_id_unique": {
+          "name": "nt_diagnoses_diagnosis_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "diagnosis_id"
+          ]
+        },
+        "nt_diagnoses_old_diagnosis_id_unique": {
+          "name": "nt_diagnoses_old_diagnosis_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "old_diagnosis_id"
+          ]
+        }
+      }
+    },
+    "public.nt_diagnoses_drafts": {
+      "name": "nt_diagnoses_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "diagnosis_draft_id": {
+          "name": "diagnosis_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "diagnosis_id": {
+          "name": "diagnosis_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "script_draft_id": {
+          "name": "script_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_diagnoses_drafts_diagnosis_id_nt_diagnoses_diagnosis_id_fk": {
+          "name": "nt_diagnoses_drafts_diagnosis_id_nt_diagnoses_diagnosis_id_fk",
+          "tableFrom": "nt_diagnoses_drafts",
+          "tableTo": "nt_diagnoses",
+          "columnsFrom": [
+            "diagnosis_id"
+          ],
+          "columnsTo": [
+            "diagnosis_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_diagnoses_drafts_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_diagnoses_drafts_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_diagnoses_drafts",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_diagnoses_drafts_script_draft_id_nt_scripts_drafts_script_draft_id_fk": {
+          "name": "nt_diagnoses_drafts_script_draft_id_nt_scripts_drafts_script_draft_id_fk",
+          "tableFrom": "nt_diagnoses_drafts",
+          "tableTo": "nt_scripts_drafts",
+          "columnsFrom": [
+            "script_draft_id"
+          ],
+          "columnsTo": [
+            "script_draft_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_diagnoses_drafts_created_by_user_id_nt_users_user_id_fk": {
+          "name": "nt_diagnoses_drafts_created_by_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_diagnoses_drafts",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_diagnoses_drafts_diagnosis_draft_id_unique": {
+          "name": "nt_diagnoses_drafts_diagnosis_draft_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "diagnosis_draft_id"
+          ]
+        }
+      }
+    },
+    "public.nt_diagnoses_history": {
+      "name": "nt_diagnoses_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diagnosis_id": {
+          "name": "diagnosis_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restore_key": {
+          "name": "restore_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_diagnoses_history_diagnosis_id_nt_diagnoses_diagnosis_id_fk": {
+          "name": "nt_diagnoses_history_diagnosis_id_nt_diagnoses_diagnosis_id_fk",
+          "tableFrom": "nt_diagnoses_history",
+          "tableTo": "nt_diagnoses",
+          "columnsFrom": [
+            "diagnosis_id"
+          ],
+          "columnsTo": [
+            "diagnosis_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_diagnoses_history_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_diagnoses_history_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_diagnoses_history",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nt_drugs_library": {
+      "name": "nt_drugs_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "drug_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'drug'"
+        },
+        "drug": {
+          "name": "drug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "min_gestation": {
+          "name": "min_gestation",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_gestation": {
+          "name": "max_gestation",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_weight": {
+          "name": "min_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_weight": {
+          "name": "max_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_age": {
+          "name": "min_age",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_age": {
+          "name": "max_age",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_feed": {
+          "name": "hourly_feed",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_feed_divider": {
+          "name": "hourly_feed_divider",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dosage_multiplier": {
+          "name": "dosage_multiplier",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_life": {
+          "name": "day_of_life",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "dosage_text": {
+          "name": "dosage_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "management_text": {
+          "name": "management_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "gestation_key": {
+          "name": "gestation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "weight_key": {
+          "name": "weight_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "diagnosis_key": {
+          "name": "diagnosis_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "age_key": {
+          "name": "age_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "age_key_id": {
+          "name": "age_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "gestation_key_id": {
+          "name": "gestation_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "weight_key_id": {
+          "name": "weight_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "diagnosis_key_id": {
+          "name": "diagnosis_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "administration_frequency": {
+          "name": "administration_frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "drug_unit": {
+          "name": "drug_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "route_of_administration": {
+          "name": "route_of_administration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "calculator_condition": {
+          "name": "calculator_condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "validation_type": {
+          "name": "validation_type",
+          "type": "dff_item_validation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_drugs_library_item_id_unique": {
+          "name": "nt_drugs_library_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_id"
+          ]
+        },
+        "nt_drugs_library_key_unique": {
+          "name": "nt_drugs_library_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      }
+    },
+    "public.nt_drugs_library_drafts": {
+      "name": "nt_drugs_library_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "item_draft_id": {
+          "name": "item_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "drug_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'drug'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_drugs_library_drafts_item_id_nt_drugs_library_item_id_fk": {
+          "name": "nt_drugs_library_drafts_item_id_nt_drugs_library_item_id_fk",
+          "tableFrom": "nt_drugs_library_drafts",
+          "tableTo": "nt_drugs_library",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_drugs_library_drafts_created_by_user_id_nt_users_user_id_fk": {
+          "name": "nt_drugs_library_drafts_created_by_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_drugs_library_drafts",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_drugs_library_drafts_item_draft_id_unique": {
+          "name": "nt_drugs_library_drafts_item_draft_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_draft_id"
+          ]
+        }
+      }
+    },
+    "public.nt_drugs_library_history": {
+      "name": "nt_drugs_library_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restore_key": {
+          "name": "restore_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_drugs_library_history_item_id_nt_drugs_library_item_id_fk": {
+          "name": "nt_drugs_library_history_item_id_nt_drugs_library_item_id_fk",
+          "tableFrom": "nt_drugs_library_history",
+          "tableTo": "nt_drugs_library",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nt_editor_info": {
+      "name": "nt_editor_info",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data_version": {
+          "name": "data_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_publish_date": {
+          "name": "last_publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_data_keys_sync_date": {
+          "name": "last_data_keys_sync_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nt_email_templates": {
+      "name": "nt_email_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_email_templates_template_id_unique": {
+          "name": "nt_email_templates_template_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "template_id"
+          ]
+        },
+        "nt_email_templates_name_unique": {
+          "name": "nt_email_templates_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.nt_files": {
+      "name": "nt_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_files_owner_id_nt_users_user_id_fk": {
+          "name": "nt_files_owner_id_nt_users_user_id_fk",
+          "tableFrom": "nt_files",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_files_file_id_unique": {
+          "name": "nt_files_file_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "file_id"
+          ]
+        }
+      }
+    },
+    "public.nt_files_chunks": {
+      "name": "nt_files_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chunk_id": {
+          "name": "chunk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_files_chunks_file_id_nt_files_file_id_fk": {
+          "name": "nt_files_chunks_file_id_nt_files_file_id_fk",
+          "tableFrom": "nt_files_chunks",
+          "tableTo": "nt_files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "file_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_files_chunks_chunk_id_unique": {
+          "name": "nt_files_chunks_chunk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chunk_id"
+          ]
+        }
+      }
+    },
+    "public.nt_hospitals": {
+      "name": "nt_hospitals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hospital_id": {
+          "name": "hospital_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "old_hospital_id": {
+          "name": "old_hospital_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hospitals_search_index": {
+          "name": "hospitals_search_index",
+          "columns": [
+            {
+              "expression": "(\n                    to_tsvector('english', \"name\")\n                )",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_hospitals_hospital_id_unique": {
+          "name": "nt_hospitals_hospital_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hospital_id"
+          ]
+        },
+        "nt_hospitals_old_hospital_id_unique": {
+          "name": "nt_hospitals_old_hospital_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "old_hospital_id"
+          ]
+        },
+        "nt_hospitals_name_unique": {
+          "name": "nt_hospitals_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.nt_hospitals_drafts": {
+      "name": "nt_hospitals_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hospital_draft_id": {
+          "name": "hospital_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "hospital_id": {
+          "name": "hospital_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_hospitals_drafts_hospital_id_nt_hospitals_hospital_id_fk": {
+          "name": "nt_hospitals_drafts_hospital_id_nt_hospitals_hospital_id_fk",
+          "tableFrom": "nt_hospitals_drafts",
+          "tableTo": "nt_hospitals",
+          "columnsFrom": [
+            "hospital_id"
+          ],
+          "columnsTo": [
+            "hospital_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_hospitals_drafts_created_by_user_id_nt_users_user_id_fk": {
+          "name": "nt_hospitals_drafts_created_by_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_hospitals_drafts",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_hospitals_drafts_hospital_draft_id_unique": {
+          "name": "nt_hospitals_drafts_hospital_draft_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hospital_draft_id"
+          ]
+        }
+      }
+    },
+    "public.nt_hospitals_history": {
+      "name": "nt_hospitals_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hospital_id": {
+          "name": "hospital_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restore_key": {
+          "name": "restore_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_hospitals_history_hospital_id_nt_hospitals_hospital_id_fk": {
+          "name": "nt_hospitals_history_hospital_id_nt_hospitals_hospital_id_fk",
+          "tableFrom": "nt_hospitals_history",
+          "tableTo": "nt_hospitals",
+          "columnsFrom": [
+            "hospital_id"
+          ],
+          "columnsTo": [
+            "hospital_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nt_languages": {
+      "name": "nt_languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iso": {
+          "name": "iso",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_languages_name_unique": {
+          "name": "nt_languages_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "nt_languages_iso_unique": {
+          "name": "nt_languages_iso_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "iso"
+          ]
+        }
+      }
+    },
+    "public.nt_mailer_settings": {
+      "name": "nt_mailer_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "setting_id": {
+          "name": "setting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "mailer_service",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_username": {
+          "name": "auth_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_password": {
+          "name": "auth_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption": {
+          "name": "encryption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "secure": {
+          "name": "secure",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_mailer_settings_setting_id_unique": {
+          "name": "nt_mailer_settings_setting_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "setting_id"
+          ]
+        },
+        "nt_mailer_settings_name_unique": {
+          "name": "nt_mailer_settings_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.nt_pending_deletion": {
+      "name": "nt_pending_deletion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_id": {
+          "name": "screen_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_script_id": {
+          "name": "screen_script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosis_id": {
+          "name": "diagnosis_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosis_script_id": {
+          "name": "diagnosis_script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "problem_script_id": {
+          "name": "problem_script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_key_id": {
+          "name": "config_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hospital_id": {
+          "name": "hospital_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drugs_library_item_id": {
+          "name": "drugs_library_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "script_draft_id": {
+          "name": "script_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_draft_id": {
+          "name": "screen_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosis_draft_id": {
+          "name": "diagnosis_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "problem_draft_id": {
+          "name": "problem_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_key_draft_id": {
+          "name": "config_key_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hospital_draft_id": {
+          "name": "hospital_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drugs_library_item_draft_id": {
+          "name": "drugs_library_item_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_key_id": {
+          "name": "data_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_key_draft_id": {
+          "name": "data_key_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_pending_deletion_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_pending_deletion_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_screen_id_nt_screens_screen_id_fk": {
+          "name": "nt_pending_deletion_screen_id_nt_screens_screen_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_screens",
+          "columnsFrom": [
+            "screen_id"
+          ],
+          "columnsTo": [
+            "screen_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_screen_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_pending_deletion_screen_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "screen_script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_diagnosis_id_nt_diagnoses_diagnosis_id_fk": {
+          "name": "nt_pending_deletion_diagnosis_id_nt_diagnoses_diagnosis_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_diagnoses",
+          "columnsFrom": [
+            "diagnosis_id"
+          ],
+          "columnsTo": [
+            "diagnosis_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_problem_id_nt_problems_problem_id_fk": {
+          "name": "nt_pending_deletion_problem_id_nt_problems_problem_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "problem_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_diagnosis_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_pending_deletion_diagnosis_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "diagnosis_script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_problem_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_pending_deletion_problem_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "problem_script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_config_key_id_nt_config_keys_config_key_id_fk": {
+          "name": "nt_pending_deletion_config_key_id_nt_config_keys_config_key_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_config_keys",
+          "columnsFrom": [
+            "config_key_id"
+          ],
+          "columnsTo": [
+            "config_key_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_hospital_id_nt_hospitals_hospital_id_fk": {
+          "name": "nt_pending_deletion_hospital_id_nt_hospitals_hospital_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_hospitals",
+          "columnsFrom": [
+            "hospital_id"
+          ],
+          "columnsTo": [
+            "hospital_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_drugs_library_item_id_nt_drugs_library_item_id_fk": {
+          "name": "nt_pending_deletion_drugs_library_item_id_nt_drugs_library_item_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_drugs_library",
+          "columnsFrom": [
+            "drugs_library_item_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_script_draft_id_nt_scripts_drafts_script_draft_id_fk": {
+          "name": "nt_pending_deletion_script_draft_id_nt_scripts_drafts_script_draft_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_scripts_drafts",
+          "columnsFrom": [
+            "script_draft_id"
+          ],
+          "columnsTo": [
+            "script_draft_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_screen_draft_id_nt_screens_drafts_screen_draft_id_fk": {
+          "name": "nt_pending_deletion_screen_draft_id_nt_screens_drafts_screen_draft_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_screens_drafts",
+          "columnsFrom": [
+            "screen_draft_id"
+          ],
+          "columnsTo": [
+            "screen_draft_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_diagnosis_draft_id_nt_diagnoses_drafts_diagnosis_draft_id_fk": {
+          "name": "nt_pending_deletion_diagnosis_draft_id_nt_diagnoses_drafts_diagnosis_draft_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_diagnoses_drafts",
+          "columnsFrom": [
+            "diagnosis_draft_id"
+          ],
+          "columnsTo": [
+            "diagnosis_draft_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_problem_draft_id_nt_problems_drafts_problem_draft_id_fk": {
+          "name": "nt_pending_deletion_problem_draft_id_nt_problems_drafts_problem_draft_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_problems_drafts",
+          "columnsFrom": [
+            "problem_draft_id"
+          ],
+          "columnsTo": [
+            "problem_draft_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_config_key_draft_id_nt_config_keys_drafts_config_key_draft_id_fk": {
+          "name": "nt_pending_deletion_config_key_draft_id_nt_config_keys_drafts_config_key_draft_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_config_keys_drafts",
+          "columnsFrom": [
+            "config_key_draft_id"
+          ],
+          "columnsTo": [
+            "config_key_draft_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_hospital_draft_id_nt_hospitals_drafts_hospital_draft_id_fk": {
+          "name": "nt_pending_deletion_hospital_draft_id_nt_hospitals_drafts_hospital_draft_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_hospitals_drafts",
+          "columnsFrom": [
+            "hospital_draft_id"
+          ],
+          "columnsTo": [
+            "hospital_draft_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_drugs_library_item_draft_id_nt_drugs_library_drafts_item_draft_id_fk": {
+          "name": "nt_pending_deletion_drugs_library_item_draft_id_nt_drugs_library_drafts_item_draft_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_drugs_library_drafts",
+          "columnsFrom": [
+            "drugs_library_item_draft_id"
+          ],
+          "columnsTo": [
+            "item_draft_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_data_key_id_nt_data_keys_uuid_fk": {
+          "name": "nt_pending_deletion_data_key_id_nt_data_keys_uuid_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_data_keys",
+          "columnsFrom": [
+            "data_key_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_data_key_draft_id_nt_data_keys_uuid_fk": {
+          "name": "nt_pending_deletion_data_key_draft_id_nt_data_keys_uuid_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_data_keys",
+          "columnsFrom": [
+            "data_key_draft_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_alias_id_nt_aliases_uuid_fk": {
+          "name": "nt_pending_deletion_alias_id_nt_aliases_uuid_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_pending_deletion_created_by_user_id_nt_users_user_id_fk": {
+          "name": "nt_pending_deletion_created_by_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_pending_deletion",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nt_problems": {
+      "name": "nt_problems",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "old_script_id": {
+          "name": "old_script_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'editor'"
+        },
+        "expression": {
+          "name": "expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "severity_order": {
+          "name": "severity_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expression_meaning": {
+          "name": "expression_meaning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "text1": {
+          "name": "text1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "text2": {
+          "name": "text2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "text3": {
+          "name": "text3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "image1": {
+          "name": "image1",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image2": {
+          "name": "image2",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image3": {
+          "name": "image3",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"fontSize\":{},\"fontWeight\":{},\"fontStyle\":{},\"textColor\":{},\"backgroundColor\":{},\"highlight\":{}}'"
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "problems_search_index": {
+          "name": "problems_search_index",
+          "columns": [
+            {
+              "expression": "(\n                    to_tsvector('english', \"name\")\n                )",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nt_problems_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_problems_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_problems",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_problems_problem_id_unique": {
+          "name": "nt_problems_problem_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "problem_id"
+          ]
+        }
+      }
+    },
+    "public.nt_problems_drafts": {
+      "name": "nt_problems_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "problem_draft_id": {
+          "name": "problem_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "script_draft_id": {
+          "name": "script_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_problems_drafts_problem_id_nt_problems_problem_id_fk": {
+          "name": "nt_problems_drafts_problem_id_nt_problems_problem_id_fk",
+          "tableFrom": "nt_problems_drafts",
+          "tableTo": "nt_problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "problem_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_problems_drafts_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_problems_drafts_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_problems_drafts",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_problems_drafts_script_draft_id_nt_scripts_drafts_script_draft_id_fk": {
+          "name": "nt_problems_drafts_script_draft_id_nt_scripts_drafts_script_draft_id_fk",
+          "tableFrom": "nt_problems_drafts",
+          "tableTo": "nt_scripts_drafts",
+          "columnsFrom": [
+            "script_draft_id"
+          ],
+          "columnsTo": [
+            "script_draft_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_problems_drafts_created_by_user_id_nt_users_user_id_fk": {
+          "name": "nt_problems_drafts_created_by_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_problems_drafts",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_problems_drafts_problem_draft_id_unique": {
+          "name": "nt_problems_drafts_problem_draft_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "problem_draft_id"
+          ]
+        }
+      }
+    },
+    "public.nt_problems_history": {
+      "name": "nt_problems_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restore_key": {
+          "name": "restore_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_problems_history_problem_id_nt_problems_problem_id_fk": {
+          "name": "nt_problems_history_problem_id_nt_problems_problem_id_fk",
+          "tableFrom": "nt_problems_history",
+          "tableTo": "nt_problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "problem_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_problems_history_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_problems_history_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_problems_history",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nt_screens": {
+      "name": "nt_screens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "screen_id": {
+          "name": "screen_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "old_screen_id": {
+          "name": "old_screen_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_script_id": {
+          "name": "old_script_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "screen_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'editor'"
+        },
+        "section_title": {
+          "name": "section_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_title": {
+          "name": "preview_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "preview_print_title": {
+          "name": "preview_print_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "skip_to_condition": {
+          "name": "skip_to_condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "skip_to_screen_id": {
+          "name": "skip_to_screen_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "epic_id": {
+          "name": "epic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ref_id_data_key": {
+          "name": "ref_id_data_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ref_key": {
+          "name": "ref_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ref_key_data_key": {
+          "name": "ref_key_data_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "step": {
+          "name": "step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "action_text": {
+          "name": "action_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "content_text": {
+          "name": "content_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "content_text_image": {
+          "name": "content_text_image",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "info_text": {
+          "name": "info_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title1": {
+          "name": "title1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "title2": {
+          "name": "title2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "title3": {
+          "name": "title3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "title4": {
+          "name": "title4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "text1": {
+          "name": "text1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "text2": {
+          "name": "text2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "text3": {
+          "name": "text3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "image1": {
+          "name": "image1",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image2": {
+          "name": "image2",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image3": {
+          "name": "image3",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "instructions2": {
+          "name": "instructions2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "instructions3": {
+          "name": "instructions3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "instructions4": {
+          "name": "instructions4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "hcw_diagnoses_instructions": {
+          "name": "hcw_diagnoses_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "suggested_diagnoses_instructions": {
+          "name": "suggested_diagnoses_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "hcw_problems_instructions": {
+          "name": "hcw_problems_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "suggested_problems_instructions": {
+          "name": "suggested_problems_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "negative_label": {
+          "name": "negative_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "positive_label": {
+          "name": "positive_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "timer_value": {
+          "name": "timer_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multiplier": {
+          "name": "multiplier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_value": {
+          "name": "min_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_value": {
+          "name": "max_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exportable": {
+          "name": "exportable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "printable": {
+          "name": "printable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skippable": {
+          "name": "skippable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "confidential": {
+          "name": "confidential",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pre_populate": {
+          "name": "pre_populate",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "items": {
+          "name": "items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"fontSize\":{},\"fontWeight\":{},\"fontStyle\":{},\"textColor\":{},\"backgroundColor\":{},\"highlight\":{}}'"
+        },
+        "drugs": {
+          "name": "drugs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "fluids": {
+          "name": "fluids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "feeds": {
+          "name": "feeds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "list_style": {
+          "name": "list_style",
+          "type": "list_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "print_display_columns": {
+          "name": "print_display_columns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "rank_items": {
+          "name": "rank_items",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_name": {
+          "name": "collection_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "collection_label": {
+          "name": "collection_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "repeatable": {
+          "name": "repeatable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "screens_search_index": {
+          "name": "screens_search_index",
+          "columns": [
+            {
+              "expression": "(\n                    to_tsvector('english', \"title\")\n                )",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nt_screens_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_screens_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_screens",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_screens_screen_id_unique": {
+          "name": "nt_screens_screen_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "screen_id"
+          ]
+        },
+        "nt_screens_old_screen_id_unique": {
+          "name": "nt_screens_old_screen_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "old_screen_id"
+          ]
+        }
+      }
+    },
+    "public.nt_screens_drafts": {
+      "name": "nt_screens_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "screen_draft_id": {
+          "name": "screen_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "screen_id": {
+          "name": "screen_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "script_draft_id": {
+          "name": "script_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "screen_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_screens_drafts_screen_id_nt_screens_screen_id_fk": {
+          "name": "nt_screens_drafts_screen_id_nt_screens_screen_id_fk",
+          "tableFrom": "nt_screens_drafts",
+          "tableTo": "nt_screens",
+          "columnsFrom": [
+            "screen_id"
+          ],
+          "columnsTo": [
+            "screen_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_screens_drafts_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_screens_drafts_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_screens_drafts",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_screens_drafts_script_draft_id_nt_scripts_drafts_script_draft_id_fk": {
+          "name": "nt_screens_drafts_script_draft_id_nt_scripts_drafts_script_draft_id_fk",
+          "tableFrom": "nt_screens_drafts",
+          "tableTo": "nt_scripts_drafts",
+          "columnsFrom": [
+            "script_draft_id"
+          ],
+          "columnsTo": [
+            "script_draft_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_screens_drafts_created_by_user_id_nt_users_user_id_fk": {
+          "name": "nt_screens_drafts_created_by_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_screens_drafts",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_screens_drafts_screen_draft_id_unique": {
+          "name": "nt_screens_drafts_screen_draft_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "screen_draft_id"
+          ]
+        }
+      }
+    },
+    "public.nt_screens_history": {
+      "name": "nt_screens_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "screen_id": {
+          "name": "screen_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restore_key": {
+          "name": "restore_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_screens_history_screen_id_nt_screens_screen_id_fk": {
+          "name": "nt_screens_history_screen_id_nt_screens_screen_id_fk",
+          "tableFrom": "nt_screens_history",
+          "tableTo": "nt_screens",
+          "columnsFrom": [
+            "screen_id"
+          ],
+          "columnsTo": [
+            "screen_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_screens_history_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_screens_history_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_screens_history",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nt_scripts": {
+      "name": "nt_scripts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "old_script_id": {
+          "name": "old_script_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "script_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admission'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'editor'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "print_title": {
+          "name": "print_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "hospital_id": {
+          "name": "hospital_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exportable": {
+          "name": "exportable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "nuid_search_enabled": {
+          "name": "nuid_search_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nuid_search_fields": {
+          "name": "nuid_search_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "reviewable": {
+          "name": "reviewable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_configurations": {
+          "name": "review_configurations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"fontSize\":{},\"fontWeight\":{},\"fontStyle\":{},\"textColor\":{},\"backgroundColor\":{},\"highlight\":{}}'"
+        },
+        "print_config": {
+          "name": "print_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\n              \"headerFormat\": \"\",\n              \"headerFields\": [],\n              \"footerFields\": [],\n              \"sections\": []\n            }'"
+        },
+        "print_sections": {
+          "name": "print_sections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "scripts_search_index": {
+          "name": "scripts_search_index",
+          "columns": [
+            {
+              "expression": "(\n                    to_tsvector('english', \"title\") ||\n                    to_tsvector('english', \"description\")\n                )",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nt_scripts_hospital_id_nt_hospitals_hospital_id_fk": {
+          "name": "nt_scripts_hospital_id_nt_hospitals_hospital_id_fk",
+          "tableFrom": "nt_scripts",
+          "tableTo": "nt_hospitals",
+          "columnsFrom": [
+            "hospital_id"
+          ],
+          "columnsTo": [
+            "hospital_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_scripts_script_id_unique": {
+          "name": "nt_scripts_script_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "script_id"
+          ]
+        },
+        "nt_scripts_old_script_id_unique": {
+          "name": "nt_scripts_old_script_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "old_script_id"
+          ]
+        }
+      }
+    },
+    "public.nt_scripts_drafts": {
+      "name": "nt_scripts_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "script_draft_id": {
+          "name": "script_draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hospital_id": {
+          "name": "hospital_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_scripts_drafts_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_scripts_drafts_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_scripts_drafts",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nt_scripts_drafts_hospital_id_nt_hospitals_hospital_id_fk": {
+          "name": "nt_scripts_drafts_hospital_id_nt_hospitals_hospital_id_fk",
+          "tableFrom": "nt_scripts_drafts",
+          "tableTo": "nt_hospitals",
+          "columnsFrom": [
+            "hospital_id"
+          ],
+          "columnsTo": [
+            "hospital_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "nt_scripts_drafts_created_by_user_id_nt_users_user_id_fk": {
+          "name": "nt_scripts_drafts_created_by_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_scripts_drafts",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_scripts_drafts_script_draft_id_unique": {
+          "name": "nt_scripts_drafts_script_draft_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "script_draft_id"
+          ]
+        }
+      }
+    },
+    "public.nt_scripts_history": {
+      "name": "nt_scripts_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_id": {
+          "name": "script_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restore_key": {
+          "name": "restore_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_scripts_history_script_id_nt_scripts_script_id_fk": {
+          "name": "nt_scripts_history_script_id_nt_scripts_script_id_fk",
+          "tableFrom": "nt_scripts_history",
+          "tableTo": "nt_scripts",
+          "columnsFrom": [
+            "script_id"
+          ],
+          "columnsTo": [
+            "script_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nt_sites": {
+      "name": "nt_sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "site_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "site_env",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'production'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_iso": {
+          "name": "country_iso",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_name": {
+          "name": "country_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_sites_site_id_unique": {
+          "name": "nt_sites_site_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "site_id"
+          ]
+        },
+        "nt_sites_name_unique": {
+          "name": "nt_sites_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "nt_sites_link_unique": {
+          "name": "nt_sites_link_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "link"
+          ]
+        }
+      }
+    },
+    "public.nt_sys": {
+      "name": "nt_sys",
+      "schema": "",
+      "columns": {
+        "_id": {
+          "name": "_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_sys_id_unique": {
+          "name": "nt_sys_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "nt_sys_key_unique": {
+          "name": "nt_sys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      }
+    },
+    "public.nt_tokens": {
+      "name": "nt_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_tokens_user_id_nt_users_user_id_fk": {
+          "name": "nt_tokens_user_id_nt_users_user_id_fk",
+          "tableFrom": "nt_tokens",
+          "tableTo": "nt_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_tokens_token_unique": {
+          "name": "nt_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      }
+    },
+    "public.nt_user_roles": {
+      "name": "nt_user_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "role_name",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_user_roles_name_unique": {
+          "name": "nt_user_roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.nt_users": {
+      "name": "nt_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role": {
+          "name": "role",
+          "type": "role_name",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_sm": {
+          "name": "avatar_sm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_md": {
+          "name": "avatar_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activation_date": {
+          "name": "activation_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_date": {
+          "name": "last_login_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_search_index": {
+          "name": "users_search_index",
+          "columns": [
+            {
+              "expression": "(\n                    to_tsvector('english', \"email\") ||\n                    to_tsvector('english', \"display_name\") ||\n                    to_tsvector('english', \"first_name\") ||\n                    to_tsvector('english', \"last_name\")\n                )",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nt_users_role_nt_user_roles_name_fk": {
+          "name": "nt_users_role_nt_user_roles_name_fk",
+          "tableFrom": "nt_users",
+          "tableTo": "nt_user_roles",
+          "columnsFrom": [
+            "role"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_users_user_id_unique": {
+          "name": "nt_users_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "nt_users_email_unique": {
+          "name": "nt_users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    },
+    "public.nt_data_keys": {
+      "name": "nt_data_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "md5(random()::text || clock_timestamp()::text)::uuid"
+        },
+        "unique_key": {
+          "name": "unique_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "md5(random()::text || clock_timestamp()::text)::uuid"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidential": {
+          "name": "confidential",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "nt_data_keys_name_idx": {
+          "name": "nt_data_keys_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nt_data_keys_name_lower_idx": {
+          "name": "nt_data_keys_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nt_data_keys_data_type_idx": {
+          "name": "nt_data_keys_data_type_idx",
+          "columns": [
+            {
+              "expression": "data_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nt_data_keys_deleted_at_idx": {
+          "name": "nt_data_keys_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_data_keys_uuid_unique": {
+          "name": "nt_data_keys_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        },
+        "nt_data_keys_unique_key_unique": {
+          "name": "nt_data_keys_unique_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "unique_key"
+          ]
+        }
+      }
+    },
+    "public.nt_data_keys_drafts": {
+      "name": "nt_data_keys_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "md5(random()::text || clock_timestamp()::text)::uuid"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unique_key": {
+          "name": "unique_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_key_id": {
+          "name": "data_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nt_data_keys_drafts_name_idx": {
+          "name": "nt_data_keys_drafts_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nt_data_keys_drafts_unique_key_idx": {
+          "name": "nt_data_keys_drafts_unique_key_idx",
+          "columns": [
+            {
+              "expression": "unique_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nt_data_keys_drafts_data_key_id_idx": {
+          "name": "nt_data_keys_drafts_data_key_id_idx",
+          "columns": [
+            {
+              "expression": "data_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nt_data_keys_drafts_data_key_id_nt_data_keys_uuid_fk": {
+          "name": "nt_data_keys_drafts_data_key_id_nt_data_keys_uuid_fk",
+          "tableFrom": "nt_data_keys_drafts",
+          "tableTo": "nt_data_keys",
+          "columnsFrom": [
+            "data_key_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_data_keys_drafts_uuid_unique": {
+          "name": "nt_data_keys_drafts_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      }
+    },
+    "public.nt_data_keys_history": {
+      "name": "nt_data_keys_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_key_id": {
+          "name": "data_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restore_key": {
+          "name": "restore_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nt_data_keys_history_data_key_id_nt_data_keys_uuid_fk": {
+          "name": "nt_data_keys_history_data_key_id_nt_data_keys_uuid_fk",
+          "tableFrom": "nt_data_keys_history",
+          "tableTo": "nt_data_keys",
+          "columnsFrom": [
+            "data_key_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nt_aliases": {
+      "name": "nt_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "md5(random()::text || clock_timestamp()::text)::uuid"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_script": {
+          "name": "old_script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nt_aliases_uuid_unique": {
+          "name": "nt_aliases_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.change_log_action": {
+      "name": "change_log_action",
+      "schema": "public",
+      "values": [
+        "create",
+        "update",
+        "delete",
+        "publish",
+        "restore",
+        "rollback",
+        "merge"
+      ]
+    },
+    "public.change_log_entity": {
+      "name": "change_log_entity",
+      "schema": "public",
+      "values": [
+        "script",
+        "screen",
+        "diagnosis",
+        "problem",
+        "config_key",
+        "drugs_library",
+        "data_key",
+        "alias",
+        "hospital",
+        "release"
+      ]
+    },
+    "public.drug_type": {
+      "name": "drug_type",
+      "schema": "public",
+      "values": [
+        "drug",
+        "fluid",
+        "feed"
+      ]
+    },
+    "public.dff_item_validation_type": {
+      "name": "dff_item_validation_type",
+      "schema": "public",
+      "values": [
+        "default",
+        "condition"
+      ]
+    },
+    "public.list_style": {
+      "name": "list_style",
+      "schema": "public",
+      "values": [
+        "none",
+        "number",
+        "bullet"
+      ]
+    },
+    "public.mailer_service": {
+      "name": "mailer_service",
+      "schema": "public",
+      "values": [
+        "gmail",
+        "smtp"
+      ]
+    },
+    "public.role_name": {
+      "name": "role_name",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "super_user"
+      ]
+    },
+    "public.screen_type": {
+      "name": "screen_type",
+      "schema": "public",
+      "values": [
+        "diagnosis",
+        "problems",
+        "checklist",
+        "form",
+        "management",
+        "multi_select",
+        "single_select",
+        "progress",
+        "timer",
+        "yesno",
+        "drugs",
+        "fluids",
+        "feeds",
+        "zw_edliz_summary_table",
+        "mwi_edliz_summary_table",
+        "edliz_summary_table",
+        "dynamic_form"
+      ]
+    },
+    "public.script_type": {
+      "name": "script_type",
+      "schema": "public",
+      "values": [
+        "admission",
+        "discharge",
+        "neolab",
+        "drecord",
+        "dff_calculator"
+      ]
+    },
+    "public.site_env": {
+      "name": "site_env",
+      "schema": "public",
+      "values": [
+        "production",
+        "stage",
+        "development",
+        "demo"
+      ]
+    },
+    "public.site_type": {
+      "name": "site_type",
+      "schema": "public",
+      "values": [
+        "nodeapi",
+        "webeditor"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/databases/pg/migrations/meta/_journal.json
+++ b/databases/pg/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1773389441378,
       "tag": "0010_dark_frog_thor",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1774595494848,
+      "tag": "0011_tearful_angel",
+      "breakpoints": true
     }
   ]
 }

--- a/databases/queries/changelogs/_get-change-logs.ts
+++ b/databases/queries/changelogs/_get-change-logs.ts
@@ -28,6 +28,7 @@ export type ChangeLogType = typeof changeLogs.$inferSelect & {
     userName?: string;
     userEmail?: string;
     entityName?: string;
+    scriptTitle?: string;
 };
 
 const SENSITIVE_KEYS = ["password", "secret", "token", "credential", "auth", "privatekey", "apikey", "salt"];
@@ -133,9 +134,13 @@ export async function _getChangeLogs(
                     name: users.displayName,
                     email: users.email,
                 },
+                script: {
+                    title: scripts.title,
+                },
             })
             .from(changeLogs)
             .leftJoin(users, eq(users.userId, changeLogs.userId))
+            .leftJoin(scripts, eq(scripts.scriptId, changeLogs.scriptId))
             .where(and(
                 !changeLogIds.length ? undefined : inArray(changeLogs.changeLogId, changeLogIds),
                 !entityIds.length ? undefined : inArray(changeLogs.entityId, entityIds),
@@ -162,6 +167,7 @@ export async function _getChangeLogs(
             userName: item.user?.name || '',
             userEmail: item.user?.email || '',
             entityName: deriveEntityName(item.changeLog),
+            scriptTitle: item.script?.title || '',
         }));
 
         const totalRes = await db
@@ -280,9 +286,13 @@ export async function _getChangeLog(
                     name: users.displayName,
                     email: users.email,
                 },
+                script: {
+                    title: scripts.title,
+                },
             })
             .from(changeLogs)
             .leftJoin(users, eq(users.userId, changeLogs.userId))
+            .leftJoin(scripts, eq(scripts.scriptId, changeLogs.scriptId))
             .where(whereChangeLogId || whereEntityAndVersion)
             .limit(1);
 
@@ -292,6 +302,7 @@ export async function _getChangeLog(
             ...changeLogRes[0].changeLog,
             userName: changeLogRes[0].user?.name || '',
             userEmail: changeLogRes[0].user?.email || '',
+            scriptTitle: changeLogRes[0].script?.title || '',
         });
 
         return { data: responseData };

--- a/lib/changelog-data-key-sync.ts
+++ b/lib/changelog-data-key-sync.ts
@@ -1,0 +1,69 @@
+function isObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value)
+}
+
+const DATA_KEY_CHANGE_TERMINALS = new Set([
+  "keyid",
+  "refid",
+  "refiddatakey",
+  "refkeyid",
+  "refkey",
+  "mindatekeyid",
+  "mindatekey",
+  "maxdatekeyid",
+  "maxdatekey",
+  "mintimekeyid",
+  "mintimekey",
+  "maxtimekeyid",
+  "maxtimekey",
+])
+
+function compareValues(a: unknown, b: unknown) {
+  try {
+    return JSON.stringify(a) === JSON.stringify(b)
+  } catch {
+    return a === b
+  }
+}
+
+function collectChangedTerminalKeys(previous: unknown, next: unknown, path: string[] = [], terminals = new Set<string>()) {
+  if (compareValues(previous, next)) return terminals
+
+  if (Array.isArray(previous) || Array.isArray(next)) {
+    const previousArray = Array.isArray(previous) ? previous : []
+    const nextArray = Array.isArray(next) ? next : []
+    const max = Math.max(previousArray.length, nextArray.length)
+
+    for (let index = 0; index < max; index++) {
+      collectChangedTerminalKeys(previousArray[index], nextArray[index], path, terminals)
+    }
+    return terminals
+  }
+
+  if (isObject(previous) || isObject(next)) {
+    const previousObject = isObject(previous) ? previous : {}
+    const nextObject = isObject(next) ? next : {}
+    const keys = new Set([...Object.keys(previousObject), ...Object.keys(nextObject)])
+
+    Array.from(keys).forEach((key) => {
+      collectChangedTerminalKeys(previousObject[key], nextObject[key], [...path, key], terminals)
+    })
+    return terminals
+  }
+
+  const terminal = (path[path.length - 1] || "").replace(/[^a-z0-9]/gi, "").toLowerCase()
+  if (terminal) terminals.add(terminal)
+  return terminals
+}
+
+export function getDataKeySyncChangeReason(previous: unknown, next: unknown): string | undefined {
+  const changedTerminals = Array.from(collectChangedTerminalKeys(previous, next).values())
+  if (!changedTerminals.length) return undefined
+
+  const matching = changedTerminals.filter((key) => DATA_KEY_CHANGE_TERMINALS.has(key))
+  if (!matching.length) return undefined
+
+  return matching.length === changedTerminals.length
+    ? "Published via data key reference sync"
+    : "Includes data key reference sync"
+}

--- a/lib/changelog-data-version-groups.ts
+++ b/lib/changelog-data-version-groups.ts
@@ -1,0 +1,135 @@
+import type { ChangeLogType } from "@/databases/queries/changelogs/_get-change-logs"
+import { normalizeChanges, resolveEntityTitle } from "@/lib/changelog-utils"
+
+const SCRIPT_SCOPED_ENTITY_TYPES = new Set<ChangeLogType["entityType"]>(["script", "screen", "diagnosis", "problem"])
+
+export type DataVersionGroupedChange = {
+  changeLogId: string
+  entityId: string
+  entityType: ChangeLogType["entityType"]
+  entityTitle: string
+  action: ChangeLogType["action"]
+  dateOfChange: ChangeLogType["dateOfChange"]
+  fieldsChanged: number
+  highlightedFields: string[]
+  changeReason?: string | null
+  description?: string | null
+  scriptId?: string | null
+}
+
+export type DataVersionScriptGroup = {
+  scriptId: string
+  scriptTitle: string
+  latestChangeAt: string | Date
+  totalChanges: number
+  entitiesAffected: number
+  fieldsChanged: number
+  screenChanges: number
+  diagnosisChanges: number
+  problemChanges: number
+  scriptChanges: number
+  changes: DataVersionGroupedChange[]
+}
+
+export type DataVersionGroupedView = {
+  scriptGroups: DataVersionScriptGroup[]
+  standaloneChanges: DataVersionGroupedChange[]
+}
+
+function toGroupedChange(change: ChangeLogType): DataVersionGroupedChange {
+  const normalizedChanges = normalizeChanges(change)
+  return {
+    changeLogId: change.changeLogId,
+    entityId: change.entityId,
+    entityType: change.entityType,
+    entityTitle: resolveEntityTitle(change),
+    action: change.action,
+    dateOfChange: change.dateOfChange,
+    fieldsChanged: normalizedChanges.length,
+    highlightedFields: normalizedChanges.slice(0, 3).map((entry) => entry.field),
+    changeReason: change.changeReason,
+    description: change.description,
+    scriptId: change.scriptId,
+  }
+}
+
+function compareByLatestChangeDesc(a: { latestChangeAt: string | Date }, b: { latestChangeAt: string | Date }) {
+  return new Date(b.latestChangeAt).getTime() - new Date(a.latestChangeAt).getTime()
+}
+
+function compareChangeDesc(a: DataVersionGroupedChange, b: DataVersionGroupedChange) {
+  return new Date(b.dateOfChange).getTime() - new Date(a.dateOfChange).getTime()
+}
+
+function buildFallbackScriptTitle(scriptId: string) {
+  return `Script ${scriptId}`
+}
+
+function resolvePreferredScriptTitle(change: ChangeLogType, groupedChange: DataVersionGroupedChange) {
+  const scriptTitle = change.scriptTitle?.trim()
+  if (scriptTitle) return scriptTitle
+  if (change.entityType === "script" && groupedChange.entityTitle.trim().length) return groupedChange.entityTitle.trim()
+  return buildFallbackScriptTitle(change.scriptId!)
+}
+
+export function buildDataVersionGroupedView(changes: ChangeLogType[]): DataVersionGroupedView {
+  const scriptGroups = new Map<string, DataVersionScriptGroup>()
+  const standaloneChanges: DataVersionGroupedChange[] = []
+
+  for (const change of changes) {
+    const groupedChange = toGroupedChange(change)
+    const isScriptScoped = !!change.scriptId && SCRIPT_SCOPED_ENTITY_TYPES.has(change.entityType)
+
+    if (!isScriptScoped || !change.scriptId) {
+      standaloneChanges.push(groupedChange)
+      continue
+    }
+
+    const existing: DataVersionScriptGroup = scriptGroups.get(change.scriptId) || {
+      scriptId: change.scriptId,
+      scriptTitle: resolvePreferredScriptTitle(change, groupedChange),
+      latestChangeAt: groupedChange.dateOfChange,
+      totalChanges: 0,
+      entitiesAffected: 0,
+      fieldsChanged: 0,
+      screenChanges: 0,
+      diagnosisChanges: 0,
+      problemChanges: 0,
+      scriptChanges: 0,
+      changes: [],
+    }
+
+    existing.totalChanges += 1
+    existing.fieldsChanged += groupedChange.fieldsChanged
+    const preferredScriptTitle = resolvePreferredScriptTitle(change, groupedChange)
+    if (existing.scriptTitle === buildFallbackScriptTitle(change.scriptId) && preferredScriptTitle !== existing.scriptTitle) {
+      existing.scriptTitle = preferredScriptTitle
+    }
+    existing.latestChangeAt =
+      new Date(groupedChange.dateOfChange).getTime() > new Date(existing.latestChangeAt).getTime()
+        ? groupedChange.dateOfChange
+        : existing.latestChangeAt
+
+    if (groupedChange.entityType === "screen") existing.screenChanges += 1
+    if (groupedChange.entityType === "diagnosis") existing.diagnosisChanges += 1
+    if (groupedChange.entityType === "problem") existing.problemChanges += 1
+    if (groupedChange.entityType === "script") existing.scriptChanges += 1
+
+    existing.changes.push(groupedChange)
+    scriptGroups.set(change.scriptId, existing)
+  }
+
+  const grouped = Array.from(scriptGroups.values()).map((group) => {
+    const uniqueEntities = new Set(group.changes.map((change) => `${change.entityType}:${change.entityId}`))
+    return {
+      ...group,
+      entitiesAffected: uniqueEntities.size,
+      changes: [...group.changes].sort(compareChangeDesc),
+    }
+  })
+
+  return {
+    scriptGroups: grouped.sort(compareByLatestChangeDesc),
+    standaloneChanges: standaloneChanges.sort(compareChangeDesc),
+  }
+}


### PR DESCRIPTION
## TICKET : [NEOAPP-1306](https://neotree.atlassian.net/browse/NEOAPP-1306)

**Summary**

This PR fixes the datakey update issue where editing one datakey could incorrectly update many unrelated entities that happened to share the same label/name. It also cleans up changelog behavior so audit entries are written at publish time instead of draft save, and improves changelog readability by grouping affected entities by script on the changelog version page.

**Problem**

Editing a datakey was triggering mass unintended updates because ref sync could fall back to legacy `name` / `label` matching instead of matching strictly by `uniqueKey`.


Before:
- same-label datakeys could cross-update unrelated references
- audit could be noisy and misleading

After:
- ref updates are scoped to explicit `uniqueKey` identity
- publish-time history is more consistent and easier to inspect
