### PR TITLE
enable manually entry text customization

### DIFF
--- a/app/(dashboard)/(scripts)/components/screens/field-items.tsx
+++ b/app/(dashboard)/(scripts)/components/screens/field-items.tsx
@@ -18,6 +18,7 @@ import { Sheet, SheetClose, SheetContent, SheetDescription, SheetHeader, SheetTi
 import { type DataKey, useDataKeysCtx } from "@/contexts/data-keys"
 import { SelectDataKey } from "@/components/select-data-key"
 import { SelectModal } from "@/components/select-modal"
+import { useAlertModal } from "@/hooks/use-alert-modal"
 
 type Item = NonNullable<ScriptField["items"]>[0]
 
@@ -185,12 +186,15 @@ function Form({
   onChange: (item: Item) => void
 }) {
   const { extractDataKeys } = useDataKeysCtx()
+  const { alert } = useAlertModal()
 
   const {
     control,
     register,
     handleSubmit,
     setValue,
+    watch,
+    formState: { errors },
   } = useForm<Item>({
     defaultValues: {
       ...item,
@@ -206,6 +210,7 @@ function Form({
       keyId: item?.keyId,
     },
   })
+  const enterValueManually = watch("enterValueManually")
 
   const forbidOptions = useMemo(() => {
     const currentItemId = item?.itemId
@@ -219,6 +224,16 @@ function Form({
 
   const onSave = handleSubmit(async (data) => {
     const manualLabel = `${data.enterValueManuallyLabel || ""}`.trim()
+
+    if (data.enterValueManually && !manualLabel) {
+      alert({
+        title: "Manual value label required",
+        message: "Add a label for the manual entry textbox before saving this option.",
+        variant: "error",
+      })
+      return
+    }
+
     const payload = {
       ...data,
       enterValueManuallyLabel: data.enterValueManually ? manualLabel : "",
@@ -341,6 +356,28 @@ function Form({
                 )
               }}
             />
+
+            {enterValueManually && (
+              <div className="px-4">
+                <Label htmlFor="enterValueManuallyLabel">Manual value label *</Label>
+                <Input
+                  {...register("enterValueManuallyLabel", {
+                    validate: (value) => {
+                      if (!enterValueManually) return true
+                      return !!`${value || ""}`.trim() || "Manual value label is required."
+                    },
+                  })}
+                  error={!!errors.enterValueManuallyLabel}
+                  placeholder="e.g. Specify medication"
+                />
+                <span className="text-xs text-muted-foreground">
+                  This label is shown on the app textbox when manual entry is enabled.
+                </span>
+                {!!errors.enterValueManuallyLabel && (
+                  <span className="text-xs text-destructive">{`${errors.enterValueManuallyLabel.message || ""}`}</span>
+                )}
+              </div>
+            )}
 
           </div>
 

--- a/app/(dashboard)/(scripts)/components/screens/item.tsx
+++ b/app/(dashboard)/(scripts)/components/screens/item.tsx
@@ -128,6 +128,7 @@ export function Item<P = {}>({
     register,
     handleSubmit,
     setValue,
+    formState: { errors },
   } = useForm({
     defaultValues: getDefaultValues(),
   })
@@ -160,6 +161,16 @@ export function Item<P = {}>({
 
   const onSave = handleSubmit(async (data) => {
     const manualLabel = `${data.enterValueManuallyLabel || ""}`.trim()
+
+    if (data.enterValueManually && !manualLabel) {
+      alert({
+        title: "Manual value label required",
+        message: "Add a label for the manual entry textbox before saving this item.",
+        variant: "error",
+      })
+      return
+    }
+
     data = {
       ...data,
       enterValueManuallyLabel: data.enterValueManually ? manualLabel : "",
@@ -535,6 +546,32 @@ export function Item<P = {}>({
                             Enter value manually if selected
                           </Label>
                         </div>
+
+                        {enterValueManually && (
+                          <div>
+                            <Label htmlFor="enterValueManuallyLabel">Manual value label *</Label>
+                            <Input
+                              {...register("enterValueManuallyLabel", {
+                                disabled,
+                                validate: (value) => {
+                                  if (!enterValueManually) return true
+                                  return !!`${value || ""}`.trim() || "Manual value label is required."
+                                },
+                              })}
+                              name="enterValueManuallyLabel"
+                              error={!disabled && !!errors.enterValueManuallyLabel}
+                              placeholder="e.g. Specify medication"
+                            />
+                            <span className="text-xs text-muted-foreground">
+                              This label is shown on the app textbox when manual entry is enabled.
+                            </span>
+                            {!!errors.enterValueManuallyLabel && (
+                              <span className="text-xs text-destructive">
+                                {`${errors.enterValueManuallyLabel.message || ""}`}
+                              </span>
+                            )}
+                          </div>
+                        )}
 
                       </>
                     )}


### PR DESCRIPTION
## TICKET: [NEOAPP1165](https://neotree.atlassian.net/browse/NEOAPP-1165)

## Summary

Restores the `Enter value manually if selected` authoring flow in the editor for screen items and field options.

This change brings back the manual label textbox when manual entry is enabled, and prevents saving unless that label is provided. The goal is to let editors correctly configure management-plan options that should show a custom text input in the app.