### PR TITLE
Introduce filter for newly introduced issues in data key integrity checker

### DIFF
--- a/app/(dashboard)/(scripts)/script/[scriptId]/data-keys/page.tsx
+++ b/app/(dashboard)/(scripts)/script/[scriptId]/data-keys/page.tsx
@@ -5,11 +5,15 @@ import { Alert } from "@/components/alert";
 
 type Props = {
     params: { scriptId: string; };
-    searchParams: { [key: string]: string; };
+    searchParams: { [key: string]: string | string[] | undefined; };
 };
 
-export default async function ScriptDataKeys({ params }: Props) {
+export default async function ScriptDataKeys({ params, searchParams }: Props) {
     const { scriptId } = await params;
+    // The publish blocker can deep-link into this page with a focused
+    // "newly introduced issues" view so users land on the exact blocking set.
+    const focusParam = Array.isArray(searchParams?.focus) ? searchParams.focus[0] : searchParams?.focus;
+    const initialFocus = focusParam === "newly_introduced" ? "newly_introduced" : "all";
 
     const [{ data: scripts, }, integrity] = await Promise.all([
         getScriptsWithItems({
@@ -36,6 +40,7 @@ export default async function ScriptDataKeys({ params }: Props) {
             <ScriptDataKeysTable 
                 data={scripts[0]}
                 integrity={integrity.data}
+                initialFocus={initialFocus}
             />
         </>
     );

--- a/app/(dashboard)/(scripts)/script/[scriptId]/data-keys/table.tsx
+++ b/app/(dashboard)/(scripts)/script/[scriptId]/data-keys/table.tsx
@@ -34,7 +34,7 @@ import {
 import { getScriptsWithItems } from "@/app/actions/scripts";
 import { Title } from "@/components/title";
 import { PageContainer } from "../../../components/page-container";
-import { getDataKeyIntegrityStatusLabel, isBlockingEntry, type DataKeyIntegrityReport } from "@/lib/data-key-integrity";
+import { getDataKeyIntegrityEntryFingerprint, getDataKeyIntegrityStatusLabel, isBlockingEntry, type DataKeyIntegrityReport } from "@/lib/data-key-integrity";
 import type { IntegrityPolicy } from "@/lib/integrity-policy";
 import { useAppContext } from "@/contexts/app";
 import { pendingChangesAPI } from "@/lib/indexed-db";
@@ -263,9 +263,10 @@ function buildImpactSummaryInlineText(summary?: IntegrityImpactSummary | null) {
     return base.replaceAll("Â·", "|");
 }
 
-export function ScriptDataKeysTable({ data: { title, scriptId }, integrity }: {
+export function ScriptDataKeysTable({ data: { title, scriptId }, integrity, initialFocus = "all" }: {
     data: Awaited<ReturnType<typeof getScriptsWithItems>>['data'][0];
-    integrity?: (DataKeyIntegrityReport & { policy?: IntegrityPolicy | null }) | null;
+    integrity?: (DataKeyIntegrityReport & { policy?: IntegrityPolicy | null; newlyIntroducedFingerprints?: string[] }) | null;
+    initialFocus?: "all" | "newly_introduced";
 }) {
     type BulkPreviewItem = Awaited<ReturnType<typeof previewDataKeyIntegrityEntriesBulk>>["previews"][number];
     const router = useRouter();
@@ -273,7 +274,9 @@ export function ScriptDataKeysTable({ data: { title, scriptId }, integrity }: {
     const { alert } = useAlertModal();
     const [isRepairing, startRepairTransition] = useTransition();
     const [resolvingKey, setResolvingKey] = useState<string | null>(null);
-    const [issueScopeFilter, setIssueScopeFilter] = useState<"all" | "blocking" | "non_blocking">("all");
+    const [issueScopeFilter, setIssueScopeFilter] = useState<"all" | "blocking" | "newly_introduced" | "non_blocking">(
+        initialFocus === "newly_introduced" ? "newly_introduced" : "all"
+    );
     const [statusFilter, setStatusFilter] = useState<"all" | DataKeyIntegrityReport["entries"][number]["status"]>("all");
     const [typeFilter, setTypeFilter] = useState<string>("all");
     const [tableSearchValue, setTableSearchValue] = useState("");
@@ -314,11 +317,15 @@ export function ScriptDataKeysTable({ data: { title, scriptId }, integrity }: {
         return `${a.location || ""}`.trim().toLowerCase().localeCompare(`${b.location || ""}`.trim().toLowerCase());
     }), [integrity?.entries]);
     const summary = integrity?.summary;
+    const newlyIntroducedFingerprintSet = useMemo(() => new Set(integrity?.newlyIntroducedFingerprints || []), [integrity?.newlyIntroducedFingerprints]);
     const availableTypes = useMemo(() => dataKeyTypes.filter((type) =>
         entries.some((entry) => `${entry.expectedDataType || ""}`.trim() === type.value)
     ), [entries]);
     const availableStatusOptions = useMemo(() => statusFilterOptions.filter((option) => {
         if (option.value === "all") return true;
+        if (issueScopeFilter === "newly_introduced") {
+            return option.value !== "resolved";
+        }
         if (issueScopeFilter === "blocking") {
             return option.value !== "resolved";
         }
@@ -328,12 +335,13 @@ export function ScriptDataKeysTable({ data: { title, scriptId }, integrity }: {
         return true;
     }), [issueScopeFilter]);
     const filteredEntries = useMemo(() => entries.filter((entry) => {
+        if (issueScopeFilter === "newly_introduced" && !newlyIntroducedFingerprintSet.has(getDataKeyIntegrityEntryFingerprint(entry))) return false;
         if (issueScopeFilter === "blocking" && !isBlockingEntry(entry)) return false;
         if (issueScopeFilter === "non_blocking" && isBlockingEntry(entry)) return false;
         if (statusFilter !== "all" && entry.status !== statusFilter) return false;
         if (typeFilter !== "all" && entry.expectedDataType !== typeFilter) return false;
         return true;
-    }), [entries, issueScopeFilter, statusFilter, typeFilter]);
+    }), [entries, issueScopeFilter, statusFilter, typeFilter, newlyIntroducedFingerprintSet]);
 
     const getEntryKey = (entry: DataKeyIntegrityReport["entries"][number]) => `${entry.kind}::${entry.location}::${entry.currentUniqueKey || entry.currentKey || ""}`;
     const bulkResolvableEntries = useMemo(() => ({
@@ -1571,6 +1579,7 @@ export function ScriptDataKeysTable({ data: { title, scriptId }, integrity }: {
                                     <SelectContent>
                                         <SelectItem value="all">All issues</SelectItem>
                                         <SelectItem value="blocking">Blocking issues</SelectItem>
+                                        <SelectItem value="newly_introduced">Newly introduced issues</SelectItem>
                                         <SelectItem value="non_blocking">Non-blocking issues</SelectItem>
                                     </SelectContent>
                                 </Select>
@@ -1636,8 +1645,10 @@ export function ScriptDataKeysTable({ data: { title, scriptId }, integrity }: {
                                 : integrity?.policy?.enforcementMode === "off"
                                     ? "Integrity enforcement is currently turned off in settings. The issue counts below still reflect the configured rule set."
                                     : integrity?.policy?.enforcementMode === "block_new_issues_only"
-                                        ? "Blocking issues match the configured rule set. In block new issues only mode, existing baseline issues may still be allowed at publish."
-                                    : "Blocking issues are the entries that currently prevent publish. Status options update based on the selected issue scope."}
+                                        ? issueScopeFilter === "newly_introduced"
+                                            ? "This view is focused on newly introduced blocking issues only. Switch the filter back to view all issues on this script."
+                                            : "Blocking issues match the configured rule set. In block new issues only mode, existing baseline issues may still be allowed at publish."
+                                        : "Blocking issues are the entries that currently prevent publish. Status options update based on the selected issue scope."}
                         </div>
 
                         {!viewOnly && hasBulkResolveActions && (

--- a/app/actions/data-keys.ts
+++ b/app/actions/data-keys.ts
@@ -12,9 +12,9 @@ import { DataKeysUsageExportRow } from '@/types/data-keys-usage-export';
 import db from '@/databases/pg/drizzle';
 import { dataKeys, dataKeysDrafts, pendingDeletion, screens, screensDrafts } from '@/databases/pg/schema';
 import { count, eq, isNull, max } from 'drizzle-orm';
-import { buildDataKeyIntegrityContext, repairSingleDataKeyIntegrityReference, scanDataKeyIntegrity, type DataKeyIntegrityEntry } from '@/lib/data-key-integrity';
+import { buildDataKeyIntegrityContext, getDataKeyIntegrityEntryFingerprint, isBlockingEntry, repairSingleDataKeyIntegrityReference, scanDataKeyIntegrity, type DataKeyIntegrityEntry } from '@/lib/data-key-integrity';
 import { _getEditorInfo } from '@/databases/queries/editor-info';
-import { getIntegrityPolicyState } from '@/lib/integrity-policy';
+import { evaluateIntegrityPolicyBlockingEntries, getIntegrityPolicyState } from '@/lib/integrity-policy';
 import socket from '@/lib/socket';
 
 type BulkIntegrityRepairItemInput = {
@@ -73,6 +73,10 @@ function buildRegistryIntegrityReport({
         rawReport,
         integrityContext,
     };
+}
+
+function getBlockingEntriesForRegistry(entries: DataKeyIntegrityEntry[]) {
+    return entries.filter((entry) => isBlockingEntry(entry));
 }
 
 function buildImpactSummary({
@@ -317,12 +321,24 @@ export const getDataKeysIntegrity = async (params?: {
             onlyIssues: params?.onlyIssues !== false,
         });
 
+        // Expose the currently enforced "newly introduced" issue set so the
+        // script registry can open directly into the same blocking slice a
+        // user saw from the publish modal.
+        const blockingEntries = getBlockingEntriesForRegistry(rawReport.entries);
+        const policyEvaluation = evaluateIntegrityPolicyBlockingEntries({
+            policy: integrityPolicyState.policy,
+            baseline: integrityPolicyState.baseline,
+            blockingEntries,
+            getFingerprint: getDataKeyIntegrityEntryFingerprint,
+        });
+
         return {
             success: true,
             data: {
                 ...rawReport,
                 policy: integrityPolicyState.policy,
                 summary: rawReport.summary,
+                newlyIntroducedFingerprints: policyEvaluation.enforcedBlockingEntries.map((entry) => getDataKeyIntegrityEntryFingerprint(entry)),
             },
         };
     } catch (e: any) {

--- a/app/actions/ops.ts
+++ b/app/actions/ops.ts
@@ -61,6 +61,42 @@ function buildPreviewEntityMap<T extends Record<string, any>>(
   )
 }
 
+async function resolveIntegrityScriptTitles(
+  entries: Array<{ scriptId?: string; scriptTitle?: string }>
+) {
+  const idsToResolve = Array.from(
+    new Set(
+      entries
+        .filter((entry) => {
+          const scriptId = `${entry.scriptId || ""}`.trim()
+          const scriptTitle = `${entry.scriptTitle || ""}`.trim()
+          return !!scriptId && (!scriptTitle || scriptTitle === scriptId)
+        })
+        .map((entry) => `${entry.scriptId || ""}`.trim())
+    )
+  )
+
+  if (!idsToResolve.length) return new Map<string, string>()
+
+  const scriptsRes = await scriptsQueries._getScripts({
+    scriptsIds: idsToResolve,
+    returnDraftsIfExist: true,
+  })
+
+  if (scriptsRes.errors?.length) {
+    throw new Error(scriptsRes.errors.join(", "))
+  }
+
+  return new Map(
+    scriptsRes.data
+      .map((script) => {
+        const title = `${script.title || ""}`.trim()
+        return title ? ([script.scriptId, title] as const) : null
+      })
+      .filter((item): item is readonly [string, string] => !!item)
+  )
+}
+
 function assertCanPublishDrafts(user?: { role?: string | null } | null) {
   const role = `${user?.role || ""}`.trim()
   const allowed = role === "admin" || role === "super_user"
@@ -813,8 +849,13 @@ export async function publishData({
       }
 
       if (enforcedBlockingEntries.length) {
+        const scriptTitlesById = await resolveIntegrityScriptTitles(enforcedBlockingEntries)
+        const enrichedBlockingEntries = enforcedBlockingEntries.map((entry) => ({
+          ...entry,
+          scriptTitle: scriptTitlesById.get(entry.scriptId) || entry.scriptTitle,
+        }))
         const enforcedReport = buildDataKeyIntegrityReportFromEntries(
-          enforcedBlockingEntries,
+          enrichedBlockingEntries,
         )
         const publishIntegrityDetails = buildDataKeyIntegrityPublishDetails(
           enforcedReport
@@ -827,6 +868,16 @@ export async function publishData({
           integrityPolicyState.policy.enforcementMode === "block_new_issues_only" &&
           publishIntegrityDetails
         ) {
+          // When publish is blocked only by newly introduced issues, send the
+          // user straight into the script registry with the same focused view.
+          publishIntegrityDetails.scripts = publishIntegrityDetails.scripts.map((script) => ({
+            ...script,
+            registryHref: `${script.registryHref}?focus=newly_introduced`,
+            issues: script.issues.map((issue) => ({
+              ...issue,
+              registryHref: `${issue.registryHref}?focus=newly_introduced`,
+            })),
+          }))
           publishIntegrityDetails.summary = [
             policyEvaluation.policyModeMessage,
             ...triggerSummary,

--- a/app/actions/scripts.ts
+++ b/app/actions/scripts.ts
@@ -339,12 +339,16 @@ export async function saveScriptScreens({
                 createdAt,
                 updatedAt,
                 isDraft,
+                isDeleted,
                 deletedAt,
                 version,
                 oldScriptId,
                 oldScreenId,
                 screenId: _ignoreScreenId,
                 scriptId: _ignoreScriptId,
+                scriptTitle: _ignoreScriptTitle,
+                hospitalName: _ignoreHospitalName,
+                draftCreatedByUserId: _ignoreDraftCreatedByUserId,
                 position,
                 ...s
             } = screen;
@@ -424,11 +428,15 @@ export async function saveScriptDiagnoses({
                 createdAt,
                 updatedAt,
                 isDraft,
+                isDeleted,
                 deletedAt,
                 version,
                 oldDiagnosisId,
                 diagnosisId: _ignoreDiagnosisId,
                 scriptId: _ignoreScriptId,
+                scriptTitle: _ignoreScriptTitle,
+                hospitalName: _ignoreHospitalName,
+                draftCreatedByUserId: _ignoreDraftCreatedByUserId,
                 position,
                 ...d
             } = diagnosis;
@@ -508,10 +516,14 @@ export async function saveScriptProblems({
                 createdAt,
                 updatedAt,
                 isDraft,
+                isDeleted,
                 deletedAt,
                 version,
                 problemId: _ignoreProblemId,
                 scriptId: _ignoreScriptId,
+                scriptTitle: _ignoreScriptTitle,
+                hospitalName: _ignoreHospitalName,
+                draftCreatedByUserId: _ignoreDraftCreatedByUserId,
                 position,
                 ...d
             } = problem;

--- a/databases/queries/scripts/_diagnoses_get.ts
+++ b/databases/queries/scripts/_diagnoses_get.ts
@@ -2,7 +2,7 @@ import { and, eq, inArray, isNotNull, isNull, or } from "drizzle-orm";
 import * as uuid from "uuid";
 
 import db from "@/databases/pg/drizzle";
-import { diagnoses, diagnosesDrafts, hospitals, pendingDeletion, scripts, } from "@/databases/pg/schema";
+import { diagnoses, diagnosesDrafts, hospitals, pendingDeletion, scripts, scriptsDrafts } from "@/databases/pg/schema";
 import logger from "@/lib/logger";
 import { DiagnosisSymptom, Preferences, ScriptImage } from "@/types";
 
@@ -90,6 +90,38 @@ export async function _getDiagnoses(
             },
         });
 
+        const draftPublishedScriptIds = Array.from(new Set(drafts.map((draft) => draft.scriptId).filter(Boolean))) as string[];
+        const draftScriptDraftIds = Array.from(new Set(drafts.map((draft) => draft.scriptDraftId).filter(Boolean))) as string[];
+
+        const [draftPublishedScripts, draftScriptDrafts] = await Promise.all([
+            !draftPublishedScriptIds.length
+                ? Promise.resolve([])
+                : db.query.scripts.findMany({
+                    where: inArray(scripts.scriptId, draftPublishedScriptIds),
+                    columns: { scriptId: true, title: true, hospitalId: true, },
+                }),
+            !draftScriptDraftIds.length
+                ? Promise.resolve([])
+                : db.query.scriptsDrafts.findMany({
+                    where: inArray(scriptsDrafts.scriptDraftId, draftScriptDraftIds),
+                    columns: { scriptDraftId: true, hospitalId: true, data: true, },
+                }),
+        ]);
+
+        const draftHospitalIds = Array.from(new Set([
+            ...draftPublishedScripts.map((script) => script.hospitalId).filter(Boolean),
+            ...draftScriptDrafts.map((script) => script.hospitalId).filter(Boolean),
+        ])) as string[];
+
+        const draftHospitals = !draftHospitalIds.length ? [] : await db.query.hospitals.findMany({
+            where: inArray(hospitals.hospitalId, draftHospitalIds),
+            columns: { hospitalId: true, name: true, },
+        });
+
+        const publishedScriptById = new Map(draftPublishedScripts.map((script) => [script.scriptId, script]));
+        const scriptDraftById = new Map(draftScriptDrafts.map((script) => [script.scriptDraftId, script]));
+        const hospitalNameById = new Map(draftHospitals.map((hospital) => [hospital.hospitalId, hospital.name]));
+
         // published diagnoses conditions
         const publishedRes = await db
             .select({
@@ -142,12 +174,24 @@ export async function _getDiagnoses(
                 isDeleted: false,
             } as GetDiagnosesResults['data'][0])),
 
-            ...drafts.map((s => ({
-                ...s.data,
-                isDraft: true,
-                isDeleted: false,
-                draftCreatedByUserId: s.createdByUserId,
-            } as GetDiagnosesResults['data'][0])))
+            ...drafts.map((s => {
+                const publishedScript = s.scriptId ? publishedScriptById.get(s.scriptId) : undefined;
+                const scriptDraft = s.scriptDraftId ? scriptDraftById.get(s.scriptDraftId) : undefined;
+                const resolvedHospitalId = publishedScript?.hospitalId || scriptDraft?.hospitalId || null;
+                const resolvedScriptTitle = publishedScript?.title || scriptDraft?.data?.title || "";
+
+                return ({
+                    ...s.data,
+                    // Diagnosis drafts can be copied across scripts, so derive
+                    // display metadata from the owning relation instead of the
+                    // stored JSON payload.
+                    scriptTitle: resolvedScriptTitle,
+                    hospitalName: resolvedHospitalId ? (hospitalNameById.get(resolvedHospitalId) || "") : "",
+                    isDraft: true,
+                    isDeleted: false,
+                    draftCreatedByUserId: s.createdByUserId,
+                } as GetDiagnosesResults['data'][0]);
+            }))
         ]
             .sort((a, b) => a.position - b.position)
             .filter(s => !inPendingDeletion.map(s => s.diagnosisId).includes(s.diagnosisId))

--- a/databases/queries/scripts/_problems_get.ts
+++ b/databases/queries/scripts/_problems_get.ts
@@ -2,7 +2,7 @@ import { and, eq, inArray, isNotNull, isNull, or } from "drizzle-orm";
 import * as uuid from "uuid";
 
 import db from "@/databases/pg/drizzle";
-import { problems, problemsDrafts, hospitals, pendingDeletion, scripts, } from "@/databases/pg/schema";
+import { problems, problemsDrafts, hospitals, pendingDeletion, scripts, scriptsDrafts } from "@/databases/pg/schema";
 import logger from "@/lib/logger";
 import { Preferences, ScriptImage } from "@/types";
 
@@ -77,6 +77,38 @@ export async function _getProblems(
             },
         });
 
+        const draftPublishedScriptIds = Array.from(new Set(drafts.map((draft) => draft.scriptId).filter(Boolean))) as string[];
+        const draftScriptDraftIds = Array.from(new Set(drafts.map((draft) => draft.scriptDraftId).filter(Boolean))) as string[];
+
+        const [draftPublishedScripts, draftScriptDrafts] = await Promise.all([
+            !draftPublishedScriptIds.length
+                ? Promise.resolve([])
+                : db.query.scripts.findMany({
+                    where: inArray(scripts.scriptId, draftPublishedScriptIds),
+                    columns: { scriptId: true, title: true, hospitalId: true, },
+                }),
+            !draftScriptDraftIds.length
+                ? Promise.resolve([])
+                : db.query.scriptsDrafts.findMany({
+                    where: inArray(scriptsDrafts.scriptDraftId, draftScriptDraftIds),
+                    columns: { scriptDraftId: true, hospitalId: true, data: true, },
+                }),
+        ]);
+
+        const draftHospitalIds = Array.from(new Set([
+            ...draftPublishedScripts.map((script) => script.hospitalId).filter(Boolean),
+            ...draftScriptDrafts.map((script) => script.hospitalId).filter(Boolean),
+        ])) as string[];
+
+        const draftHospitals = !draftHospitalIds.length ? [] : await db.query.hospitals.findMany({
+            where: inArray(hospitals.hospitalId, draftHospitalIds),
+            columns: { hospitalId: true, name: true, },
+        });
+
+        const publishedScriptById = new Map(draftPublishedScripts.map((script) => [script.scriptId, script]));
+        const scriptDraftById = new Map(draftScriptDrafts.map((script) => [script.scriptDraftId, script]));
+        const hospitalNameById = new Map(draftHospitals.map((hospital) => [hospital.hospitalId, hospital.name]));
+
         // published problems conditions
         const publishedRes = await db
             .select({
@@ -129,12 +161,24 @@ export async function _getProblems(
                 isDeleted: false,
             } as GetProblemsResults['data'][0])),
 
-            ...drafts.map((s => ({
-                ...s.data,
-                isDraft: true,
-                isDeleted: false,
-                draftCreatedByUserId: s.createdByUserId,
-            } as GetProblemsResults['data'][0])))
+            ...drafts.map((s => {
+                const publishedScript = s.scriptId ? publishedScriptById.get(s.scriptId) : undefined;
+                const scriptDraft = s.scriptDraftId ? scriptDraftById.get(s.scriptDraftId) : undefined;
+                const resolvedHospitalId = publishedScript?.hospitalId || scriptDraft?.hospitalId || null;
+                const resolvedScriptTitle = publishedScript?.title || scriptDraft?.data?.title || "";
+
+                return ({
+                    ...s.data,
+                    // Problem drafts can be copied between scripts; resolve the
+                    // current owner name from relations so publish blockers and
+                    // registries point at the right script.
+                    scriptTitle: resolvedScriptTitle,
+                    hospitalName: resolvedHospitalId ? (hospitalNameById.get(resolvedHospitalId) || "") : "",
+                    isDraft: true,
+                    isDeleted: false,
+                    draftCreatedByUserId: s.createdByUserId,
+                } as GetProblemsResults['data'][0]);
+            }))
         ]
             .sort((a, b) => a.position - b.position)
             .filter(s => !inPendingDeletion.map(s => s.problemId).includes(s.problemId))

--- a/databases/queries/scripts/_screens_get.ts
+++ b/databases/queries/scripts/_screens_get.ts
@@ -2,7 +2,7 @@ import { and, eq, inArray, isNotNull, isNull, or } from "drizzle-orm";
 import * as uuid from "uuid";
 
 import db from "@/databases/pg/drizzle";
-import { screens, screensDrafts, pendingDeletion, scripts, hospitals } from "@/databases/pg/schema";
+import { screens, screensDrafts, pendingDeletion, scripts, scriptsDrafts, hospitals } from "@/databases/pg/schema";
 import logger from "@/lib/logger";
 import { DrugField, ScriptField, ScriptItem, ScriptImage, Preferences } from "@/types";
 
@@ -98,6 +98,38 @@ export async function _getScreens(
             },
         });
 
+        const draftPublishedScriptIds = Array.from(new Set(drafts.map((draft) => draft.scriptId).filter(Boolean))) as string[];
+        const draftScriptDraftIds = Array.from(new Set(drafts.map((draft) => draft.scriptDraftId).filter(Boolean))) as string[];
+
+        const [draftPublishedScripts, draftScriptDrafts] = await Promise.all([
+            !draftPublishedScriptIds.length
+                ? Promise.resolve([])
+                : db.query.scripts.findMany({
+                    where: inArray(scripts.scriptId, draftPublishedScriptIds),
+                    columns: { scriptId: true, title: true, hospitalId: true, },
+                }),
+            !draftScriptDraftIds.length
+                ? Promise.resolve([])
+                : db.query.scriptsDrafts.findMany({
+                    where: inArray(scriptsDrafts.scriptDraftId, draftScriptDraftIds),
+                    columns: { scriptDraftId: true, hospitalId: true, data: true, },
+                }),
+        ]);
+
+        const draftHospitalIds = Array.from(new Set([
+            ...draftPublishedScripts.map((script) => script.hospitalId).filter(Boolean),
+            ...draftScriptDrafts.map((script) => script.hospitalId).filter(Boolean),
+        ])) as string[];
+
+        const draftHospitals = !draftHospitalIds.length ? [] : await db.query.hospitals.findMany({
+            where: inArray(hospitals.hospitalId, draftHospitalIds),
+            columns: { hospitalId: true, name: true, },
+        });
+
+        const publishedScriptById = new Map(draftPublishedScripts.map((script) => [script.scriptId, script]));
+        const scriptDraftById = new Map(draftScriptDrafts.map((script) => [script.scriptDraftId, script]));
+        const hospitalNameById = new Map(draftHospitals.map((hospital) => [hospital.hospitalId, hospital.name]));
+
         // published screens conditions
         const publishedRes = await db
             .select({
@@ -151,12 +183,24 @@ export async function _getScreens(
                 isDeleted: false,
             } as GetScreensResults['data'][0])),
 
-            ...drafts.map((s => ({
-                ...s.data,
-                isDraft: true,
-                isDeleted: false,
-                draftCreatedByUserId: s.createdByUserId,
-            } as GetScreensResults['data'][0])))
+            ...drafts.map((s => {
+                const publishedScript = s.scriptId ? publishedScriptById.get(s.scriptId) : undefined;
+                const scriptDraft = s.scriptDraftId ? scriptDraftById.get(s.scriptDraftId) : undefined;
+                const resolvedHospitalId = publishedScript?.hospitalId || scriptDraft?.hospitalId || null;
+                const resolvedScriptTitle = publishedScript?.title || scriptDraft?.data?.title || "";
+
+                return ({
+                    ...s.data,
+                    // Never trust copied draft payload metadata for ownership
+                    // display; always derive the script name from the current
+                    // owning script/script draft relation.
+                    scriptTitle: resolvedScriptTitle,
+                    hospitalName: resolvedHospitalId ? (hospitalNameById.get(resolvedHospitalId) || "") : "",
+                    isDraft: true,
+                    isDeleted: false,
+                    draftCreatedByUserId: s.createdByUserId,
+                } as GetScreensResults['data'][0]);
+            }))
         ]
             .sort((a, b) => a.position - b.position)
             .filter(s => !inPendingDeletion.map(s => s.screenId).includes(s.screenId));

--- a/lib/data-key-integrity.ts
+++ b/lib/data-key-integrity.ts
@@ -878,12 +878,26 @@ export function buildDataKeyIntegrityPublishDetails(
     const blocking = getBlockingIntegrityEntries(report.entries);
     if (!blocking.length) return null;
 
-    const grouped = new Map<string, DataKeyIntegrityEntry[]>();
+    const grouped = new Map<string, {
+        scriptId: string;
+        scriptTitle: string;
+        entries: DataKeyIntegrityEntry[];
+    }>();
     for (const entry of blocking) {
-        const key = `${entry.scriptId}::${entry.scriptTitle || entry.scriptId}`;
-        const current = grouped.get(key) || [];
-        current.push(entry);
-        grouped.set(key, current);
+        const scriptId = `${entry.scriptId || ""}`.trim();
+        if (!scriptId) continue;
+        const current = grouped.get(scriptId) || {
+            scriptId,
+            scriptTitle: `${entry.scriptTitle || ""}`.trim(),
+            entries: [],
+        };
+        // At this point script titles should already be enriched from the
+        // owning script. Never fall back to showing raw internal ids here.
+        if (entry.scriptTitle) {
+            current.scriptTitle = `${entry.scriptTitle}`.trim();
+        }
+        current.entries.push(entry);
+        grouped.set(scriptId, current);
     }
 
     const countsByRule = blocking.reduce((acc, entry) => {
@@ -903,9 +917,7 @@ export function buildDataKeyIntegrityPublishDetails(
             `Publish blocked: ${blocking.length} data key validation issue${blocking.length === 1 ? "" : "s"} found across ${grouped.size} script${grouped.size === 1 ? "" : "s"}.`,
             `Blocking rules triggered: ${topLevelSummary}.`,
         ],
-        scripts: Array.from(grouped.entries()).map(([groupKey, entries]) => {
-            const [scriptId, scriptTitleRaw] = groupKey.split("::");
-            const scriptTitle = scriptTitleRaw || scriptId;
+        scripts: Array.from(grouped.values()).map(({ scriptId, scriptTitle, entries }) => {
             return {
                 scriptId,
                 scriptTitle,


### PR DESCRIPTION
Add a filter to the data key integrity checker screen to allow users to focus on newly introduced issues, enhancing usability and navigation. This change supports deep-linking to specific views for improved user experience.