### PR TITLE
datakeys search

### DIFF
--- a/app/(dashboard)/data-keys/components/table.tsx
+++ b/app/(dashboard)/data-keys/components/table.tsx
@@ -69,6 +69,7 @@ export function DataKeysTable({ disabled, }: {
             inputPlaceholder: 'Search data keys',
             value: searchValue,
             setValue: setSearchValue,
+            filterRows: false,
         },
         noDataMessage: (
             <div className="mt-4 flex flex-col items-center justify-center gap-y-2">

--- a/components/data-table/hooks.ts
+++ b/components/data-table/hooks.ts
@@ -41,6 +41,7 @@ export function useTable({ props: _props }: {
 
     const [internalSearchValue, setInternalSearchValue] = useState(''); 
     const searchValue = useDebounce(search?.value || internalSearchValue);
+    const filterRows = search?.filterRows !== false;
     const setSearchValue = useCallback((value = '') => {
         // if (search?.setValue) {
         //     search?.setValue(value);
@@ -125,7 +126,10 @@ export function useTable({ props: _props }: {
         if (mounted.current) {
             let filteredRows: undefined | Parameters<NonNullable<DataTableProps['onFilteredRowsChange']>>[0] = undefined;
             setState(prev => {
-                const rows = getFilteredRows({ rows: prev.unfilteredRows, searchValue, });
+                const rows = getFilteredRows({
+                    rows: prev.unfilteredRows,
+                    searchValue: filterRows ? searchValue : undefined,
+                });
                 if (JSON.stringify(prev.rows) === (JSON.stringify(rows))) return prev;
                 filteredRows = rows.map(r => ({ rowIndex: r.rowIndex, }));
                 return {
@@ -135,7 +139,7 @@ export function useTable({ props: _props }: {
             });
             if (filteredRows) onFilteredRowsChange?.(filteredRows);
         }
-    }, [state.rows, searchValue]);
+    }, [state.rows, searchValue, filterRows]);
 
     useEffect(() => {
         setState(prev => ({

--- a/components/data-table/types.ts
+++ b/components/data-table/types.ts
@@ -48,6 +48,8 @@ export type DataTableSearchOptions = {
     inputPlaceholder?: string;
     value?: string;
     setValue?: (value: string) => void;
+    /** Set to false when the parent already supplies filtered rows. */
+    filterRows?: boolean;
 };
 
 export type DataTableHeaderProps = {

--- a/contexts/data-keys/index.tsx
+++ b/contexts/data-keys/index.tsx
@@ -22,7 +22,7 @@ import { _getDataKeys, } from "@/databases/queries/data-keys";
 import { Pagination } from "@/types";
 import { recordPendingDeletionChange } from "@/lib/change-tracker";
 import { useAppContext } from "@/contexts/app";
-import { normalizeSearchTerm } from "@/lib/search";
+import { matchesDataKeySearch } from "@/lib/data-keys-search";
 
 
 function paginateData<T>(
@@ -229,20 +229,7 @@ export function DataKeysCtxProvider({
 
 
         if (searchValue) {
-            const { normalizedValue, isExactMatch } = normalizeSearchTerm(searchValue);
-
-            if (normalizedValue) {
-                filtered = filtered.filter(dataKey => {
-                    const searchableFields = [
-                        dataKey.name || '',
-                        dataKey.label || '',
-                    ].map(field => field.toLowerCase());
-
-                    return searchableFields.some(field =>
-                        isExactMatch ? field === normalizedValue : field.includes(normalizedValue)
-                    );
-                });
-            }
+            filtered = filtered.filter(dataKey => matchesDataKeySearch(dataKey, searchValue));
         }
 
         return filtered;

--- a/lib/data-keys-search.ts
+++ b/lib/data-keys-search.ts
@@ -1,0 +1,18 @@
+import { normalizeSearchTerm } from "@/lib/search";
+
+type SearchableDataKey = {
+    name?: string | null;
+    label?: string | null;
+};
+
+export function matchesDataKeySearch(dataKey: SearchableDataKey, searchValue: string) {
+    const { normalizedValue, isExactMatch } = normalizeSearchTerm(searchValue);
+
+    if (!normalizedValue) return true;
+
+    return [dataKey.name || '', dataKey.label || ''].some(field =>
+        isExactMatch
+            ? field === normalizedValue
+            : field.toLowerCase().includes(normalizedValue)
+    );
+}


### PR DESCRIPTION
Ticket: [NEOAPP1406](https://neotree.atlassian.net/browse/NEOAPP-1406)

Adds quoted exact-match search to the Data Keys library, supporting both `"..."` and `'...'` syntax. Regular searches remain partial and case-insensitive, while quoted searches match the full key or label consistently with the Scripts table. Includes regression tests.