### PR TITLE
fix scripts imports

### DIFF
--- a/databases/mutations/scripts/_scripts_publish.ts
+++ b/databases/mutations/scripts/_scripts_publish.ts
@@ -1,5 +1,4 @@
 import { and, eq, inArray, isNotNull, or, sql } from "drizzle-orm"
-import { v4 } from "uuid"
 
 import { _saveChangeLogs, type SaveChangeLogData } from "@/databases/mutations/changelogs/_save-change-log"
 import logger from "@/lib/logger"
@@ -18,6 +17,7 @@ import { removeHexCharacters } from "@/databases/utils"
 import { _saveScriptsHistory } from "./_scripts_history"
 import { getPublishedEntityVersion } from "@/lib/changelog-rollback"
 import { buildDeleteChangeSnapshots } from "@/lib/changelog-publish"
+import { buildPublishedChildScriptReference, resolvePublishedScriptId } from "@/lib/script-draft-publish"
 
 export async function _publishScripts({
   userId,
@@ -48,7 +48,7 @@ export async function _publishScripts({
     const inserts = drafts
       .filter((c) => !c.scriptId)
       .map((draft) => {
-        const resolvedScriptId = draft.data.scriptId || draft.scriptDraftId || v4()
+        const resolvedScriptId = resolvePublishedScriptId(draft)
         return {
           ...draft,
           scriptId: resolvedScriptId,
@@ -134,44 +134,6 @@ export async function _publishScripts({
         }
       }
 
-      for (const insertedScript of inserts) {
-        const scriptId = insertedScript.data.scriptId!
-        await executor
-          .update(screensDrafts)
-          .set({ scriptId })
-          .where(
-            or(
-              eq(screensDrafts.scriptId, insertedScript.scriptDraftId),
-              eq(screensDrafts.scriptDraftId, insertedScript.scriptDraftId),
-              eq(screensDrafts.scriptId, scriptId),
-              eq(screensDrafts.scriptDraftId, scriptId),
-            ),
-          )
-
-        await executor
-          .update(diagnosesDrafts)
-          .set({ scriptId })
-          .where(
-            or(
-              eq(diagnosesDrafts.scriptId, insertedScript.scriptDraftId),
-              eq(diagnosesDrafts.scriptDraftId, insertedScript.scriptDraftId),
-              eq(diagnosesDrafts.scriptId, scriptId),
-              eq(diagnosesDrafts.scriptDraftId, scriptId),
-            ),
-          )
-
-        await executor
-          .update(problemsDrafts)
-          .set({ scriptId })
-          .where(
-            or(
-              eq(problemsDrafts.scriptId, insertedScript.scriptDraftId),
-              eq(problemsDrafts.scriptDraftId, insertedScript.scriptDraftId),
-              eq(problemsDrafts.scriptId, scriptId),
-              eq(problemsDrafts.scriptDraftId, scriptId),
-            ),
-          )
-      }
       const insertChangeLogs = await _saveScriptsHistory({
         drafts: persistedInserts,
         previous: dataBefore,
@@ -182,6 +144,35 @@ export async function _publishScripts({
         ...log,
         dataVersion: dataVersion
       })))
+    }
+
+    // Child drafts retain a cascading foreign key to the script draft. Move
+    // them onto the published script before deleting the parent draft so they
+    // remain available to the child publishers that run next.
+    for (const draft of drafts) {
+      const childScriptReference = buildPublishedChildScriptReference(draft)
+
+      await executor
+        .update(screensDrafts)
+        .set(childScriptReference)
+        .where(eq(screensDrafts.scriptDraftId, draft.scriptDraftId))
+
+      await executor
+        .update(diagnosesDrafts)
+        .set(childScriptReference)
+        .where(eq(diagnosesDrafts.scriptDraftId, draft.scriptDraftId))
+
+      await executor
+        .update(problemsDrafts)
+        .set(childScriptReference)
+        .where(eq(problemsDrafts.scriptDraftId, draft.scriptDraftId))
+
+      // Child deletion requests use the same cascading parent-draft foreign
+      // key. Keep them alive so the child publishers can apply them next.
+      await executor
+        .update(pendingDeletion)
+        .set({ scriptDraftId: null })
+        .where(eq(pendingDeletion.scriptDraftId, draft.scriptDraftId))
     }
 
     let deleted = await executor.query.pendingDeletion.findMany({

--- a/lib/script-draft-publish.ts
+++ b/lib/script-draft-publish.ts
@@ -1,0 +1,18 @@
+export type PublishableScriptDraft = {
+  scriptDraftId: string
+  scriptId?: string | null
+  data?: {
+    scriptId?: string | null
+  } | null
+}
+
+export function resolvePublishedScriptId(draft: PublishableScriptDraft) {
+  return draft.scriptId || draft.data?.scriptId || draft.scriptDraftId
+}
+
+export function buildPublishedChildScriptReference(draft: PublishableScriptDraft) {
+  return {
+    scriptId: resolvePublishedScriptId(draft),
+    scriptDraftId: null,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
         "test:integrity-scan-scope": "tsx tests/integrity-scan-scope.test.ts",
         "test:integrity-baseline": "tsx tests/integrity-baseline.test.ts",
         "test:integrity-imports": "tsx tests/integrity-imports.test.ts",
-        "test": "tsx tests/changelog-version-authority.test.ts && tsx tests/changelog-rollback-draft-guard.test.ts && tsx tests/integrity-policy.test.ts && tsx tests/data-key-integrity.test.ts && tsx tests/integrity-draft-origin.test.ts && tsx tests/integrity-scan-scope.test.ts && tsx tests/integrity-baseline.test.ts && tsx tests/integrity-imports.test.ts"
+        "test:script-draft-publish": "tsx tests/script-draft-publish.test.ts",
+        "test": "tsx tests/changelog-version-authority.test.ts && tsx tests/changelog-rollback-draft-guard.test.ts && tsx tests/integrity-policy.test.ts && tsx tests/data-key-integrity.test.ts && tsx tests/integrity-draft-origin.test.ts && tsx tests/integrity-scan-scope.test.ts && tsx tests/integrity-baseline.test.ts && tsx tests/integrity-imports.test.ts && tsx tests/script-draft-publish.test.ts"
     },
     "dependencies": {
         "@auth/drizzle-adapter": "^1.4.1",

--- a/tests/script-draft-publish.test.ts
+++ b/tests/script-draft-publish.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import {
+  buildPublishedChildScriptReference,
+  resolvePublishedScriptId,
+} from "../lib/script-draft-publish"
+
+const importedScriptDraft = {
+  scriptDraftId: "import-draft-id",
+  scriptId: null,
+  data: { scriptId: "imported-script-id" },
+}
+
+assert.equal(
+  resolvePublishedScriptId(importedScriptDraft),
+  "imported-script-id",
+  "new imported scripts should use the ID that is promoted into the published script row",
+)
+assert.deepEqual(
+  buildPublishedChildScriptReference(importedScriptDraft),
+  { scriptId: "imported-script-id", scriptDraftId: null },
+  "imported child drafts must be detached from the cascading parent draft reference",
+)
+
+const updatedScriptDraft = {
+  scriptDraftId: "update-draft-id",
+  scriptId: "published-script-id",
+  data: { scriptId: "stale-or-legacy-id" },
+}
+
+assert.deepEqual(
+  buildPublishedChildScriptReference(updatedScriptDraft),
+  { scriptId: "published-script-id", scriptDraftId: null },
+  "children of updated scripts should retain the authoritative published script ID",
+)
+
+const publishSource = readFileSync(
+  resolve(process.cwd(), "databases/mutations/scripts/_scripts_publish.ts"),
+  "utf8",
+)
+const reparentIndex = publishSource.indexOf("const childScriptReference = buildPublishedChildScriptReference(draft)")
+const pendingDeletionDetachIndex = publishSource.indexOf(".set({ scriptDraftId: null })")
+const parentDeleteIndex = publishSource.indexOf("delete(scriptsDrafts)")
+
+assert.ok(reparentIndex >= 0, "script publishing should reparent child drafts")
+assert.ok(parentDeleteIndex > reparentIndex, "child drafts must be detached before the parent script draft is deleted")
+assert.ok(
+  pendingDeletionDetachIndex > reparentIndex && pendingDeletionDetachIndex < parentDeleteIndex,
+  "pending child deletions must be detached before the parent script draft is deleted",
+)
+
+for (const table of ["screensDrafts", "diagnosesDrafts", "problemsDrafts"]) {
+  assert.match(
+    publishSource,
+    new RegExp(`update\\(${table}\\)[\\s\\S]*?set\\(childScriptReference\\)`),
+    `${table} should be reparented before script draft cleanup`,
+  )
+}
+
+assert.match(
+  publishSource,
+  /update\(pendingDeletion\)[\s\S]*?set\(\{ scriptDraftId: null \}\)/,
+  "pending child deletions should be detached from the parent script draft",
+)
+
+console.log("script draft publish tests passed")


### PR DESCRIPTION
# Ticket [NEOAPP-1407](https://neotree.atlassian.net/browse/NEOAPP-1407)

## Summary

Fixes imported script children disappearing after publishing.

Before deleting the parent script draft, screens, diagnoses, problems, and pending child deletions are now linked safely to the published script. This prevents cascading foreign-key deletion and allows the child publishers to process them normally.

